### PR TITLE
优化Fantasy的UI工作流，新增三种复用滑动列表

### DIFF
--- a/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/ContentSizeFitterEditor.cs
+++ b/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/ContentSizeFitterEditor.cs
@@ -1,0 +1,30 @@
+﻿using UnityEditor;
+using UnityEngine.UI;
+
+namespace Fantasy
+{
+    [CustomEditor(typeof(ContentSizeFitter), true)]
+    [CanEditMultipleObjects]
+    public class ContentSizeFitterEditor: UnityEditor.UI.ContentSizeFitterEditor
+    {
+        private ContentSizeFitter _target;
+        private int _targetInstanceId;
+
+        protected override void OnEnable()
+        {
+            _target = (ContentSizeFitter)target;
+            _targetInstanceId = _target.GetInstanceID();
+            base.OnEnable();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            EditorGUI.BeginChangeCheck();
+            base.OnInspectorGUI();
+            if (EditorGUI.EndChangeCheck())
+            {
+                FantasyEditorEventHelper.Trigger(_targetInstanceId);
+            }
+        }
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/EditorIcons.cs
+++ b/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/EditorIcons.cs
@@ -1,0 +1,655 @@
+﻿using System;
+
+#if UNITY_EDITOR
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+using System.Linq;
+
+// ReSharper disable StringLiteralTypo
+// ReSharper disable CollectionNeverQueried.Local
+
+public class EditorIcons : EditorWindow
+{
+    [MenuItem("Tools/Editor Icons %e", priority = -1001)]
+    public static void EditorIconsOpen()
+    {
+        var w = CreateWindow<EditorIcons>("Editor Icons");
+        w.ShowUtility();
+        w.minSize = new Vector2(320, 450);
+    }
+
+    private static bool _viewBigIcons = true;
+
+    private static bool _darkPreview = true;
+
+    private Vector2 _scroll;
+
+    private int _buttonSize = 70;
+
+    private string _search = "";
+
+    private void SearchGUI()
+    {
+        using (new GUILayout.HorizontalScope())
+        {
+            if (IsWide) GUILayout.Space(10);
+
+            _search = EditorGUILayout.TextField(_search, EditorStyles.toolbarSearchField);
+            if (GUILayout.Button(EditorGUIUtility.IconContent("winbtn_mac_close_h"), //SVN_DeletedLocal
+                    EditorStyles.toolbarButton,
+                    GUILayout.Width(22))
+               ) _search = "";
+        }
+    }
+
+    private bool IsWide => Screen.width > 550;
+
+    private bool DoSearch => !string.IsNullOrWhiteSpace(_search) && _search != "";
+
+    private GUIContent GetIcon(string iconName)
+    {
+        GUIContent valid = null;
+        Debug.unityLogger.logEnabled = false;
+        if (!string.IsNullOrEmpty(iconName)) valid = EditorGUIUtility.IconContent(iconName);
+        Debug.unityLogger.logEnabled = true;
+        return valid?.image == null ? null : valid;
+    }
+
+    private void OnEnable()
+    {
+        //InitIcons();
+        //var all_icons = iconContentListAll.Select(x => x.tooltip).ToArray();
+        var allIcons = IcoList.Where(x => GetIcon(x) != null).ToArray();
+        //List<string> found = new List<string>();
+        List<string> unique = new List<string>();
+        //var skip_flag = HideFlags.HideInInspector | HideFlags.HideAndDontSave;
+        //int unique_to_resources = 0, skipped_empty_str = 0, skipped_flags = 0, 
+        //    skipped_not_persistent = 0, skipped_nulls = 0, unique_to_list = 0;
+
+        foreach (Texture2D x in Resources.FindObjectsOfTypeAll<Texture2D>())
+        {
+            //if (string.IsNullOrEmpty(x.name)) skipped_empty_str++;                                      // skipped 10 empty
+            //if (!EditorUtility.IsPersistent(x)) skipped_not_persistent++;                               // skipped 39 none persistent
+            //if (x.hideFlags != HideFlags.HideAndDontSave && x.hideFlags != skip_flag) skipped_flags++;  // skipped 27 icons
+
+            GUIContent icoContent = GetIcon(x.name);
+            if (icoContent == null) continue; // skipped 14 icons 
+            //{ 
+            //    skipped_nulls++; 
+            //    continue; 
+            //}
+
+            if (!allIcons.Contains(x.name))
+            {
+                //unique_to_resources++;
+                unique.Add(x.name);
+            }
+
+            //found.Add( x.name );
+        }
+
+        //foreach (var ico in all_icons) if (!found.Contains(ico)) unique_to_list++;
+
+        //Debug.Log( $"Resources skipped nulls={skipped_nulls} empty={skipped_empty_str} flags={skipped_flags}" );
+        //Debug.Log("Resources skipped_not_persistent=" + skipped_not_persistent);
+        //Debug.Log($"totals , list: {all_icons.Length} resource: {found.Count}");
+        //Debug.Log($"Unique list={ unique_to_list } resources={unique_to_resources}") ;
+
+        IcoList = IcoList.ToList().Concat(unique).ToArray();
+
+        // Static list icons count : 1315 ( unique = 749 )
+        // Found icons in resources : 1416 ( unique = 855 )
+
+        Resources.UnloadUnusedAssets();
+        GC.Collect();
+    }
+
+    private void OnGUI()
+    {
+        var ppp = EditorGUIUtility.pixelsPerPoint;
+
+        InitIcons();
+
+        if (!IsWide) SearchGUI();
+
+        using (new GUILayout.HorizontalScope(EditorStyles.toolbar))
+        {
+            GUILayout.Label("Select what icons to show", GUILayout.Width(160));
+            _viewBigIcons = GUILayout.SelectionGrid(
+                _viewBigIcons ? 1 : 0, new[] { "Small", "Big" },
+                2, EditorStyles.toolbarButton) == 1;
+
+            if (IsWide) SearchGUI();
+        }
+
+        if (IsWide) GUILayout.Space(3);
+
+        using (var scope = new GUILayout.ScrollViewScope(_scroll))
+        {
+            GUILayout.Space(10);
+
+            _scroll = scope.scrollPosition;
+
+            _buttonSize = _viewBigIcons ? 70 : 40;
+
+            // scrollbar_width = ~ 12.5
+            var renderWidth = (Screen.width / ppp - 13f);
+            var gridW = Mathf.FloorToInt(renderWidth / _buttonSize);
+            var marginLeft = (renderWidth - _buttonSize * gridW) / 2;
+
+            int row = 0, index = 0;
+
+            List<GUIContent> iconList;
+
+            if (DoSearch)
+                iconList = _iconContentListAll.Where(x => x.tooltip.ToLower()
+                    .Contains(_search.ToLower())).ToList();
+            else iconList = _viewBigIcons ? _iconContentListBig : _iconContentListSmall;
+
+            while (index < iconList.Count)
+            {
+                using (new GUILayout.HorizontalScope())
+                {
+                    GUILayout.Space(marginLeft);
+
+                    for (var i = 0; i < gridW; ++i)
+                    {
+                        int k = i + row * gridW;
+
+                        var icon = iconList[k];
+
+                        if (GUILayout.Button(icon,
+                                _iconButtonStyle,
+                                GUILayout.Width(_buttonSize),
+                                GUILayout.Height(_buttonSize)))
+                        {
+                            EditorGUI.FocusTextInControl("");
+                            _iconSelected = icon;
+                        }
+
+                        index++;
+
+                        if (index == iconList.Count) break;
+                    }
+                }
+
+                row++;
+            }
+
+            GUILayout.Space(10);
+        }
+
+
+        if (_iconSelected == null) return;
+
+        GUILayout.FlexibleSpace();
+
+        using (new GUILayout.HorizontalScope(EditorStyles.helpBox, GUILayout.MaxHeight(_viewBigIcons ? 140 : 120)))
+        {
+            using (new GUILayout.VerticalScope(GUILayout.Width(130)))
+            {
+                GUILayout.Space(2);
+
+                GUILayout.Button(_iconSelected,
+                    _darkPreview ? _iconPreviewBlack : _iconPreviewWhite,
+                    GUILayout.Width(128), GUILayout.Height(_viewBigIcons ? 128 : 40));
+
+                GUILayout.Space(5);
+
+                _darkPreview = GUILayout.SelectionGrid(
+                    _darkPreview ? 1 : 0, new[] { "Light", "Dark" },
+                    2, EditorStyles.miniButton) == 1;
+
+                GUILayout.FlexibleSpace();
+            }
+
+            GUILayout.Space(10);
+
+            using (new GUILayout.VerticalScope())
+            {
+                var s = $"Size: {_iconSelected.image.width}x{_iconSelected.image.height}";
+                s += "\nIs Pro Skin Icon: " + (_iconSelected.tooltip.IndexOf("d_", StringComparison.Ordinal) == 0 ? "Yes" : "No");
+                s += $"\nTotal {_iconContentListAll.Count} icons";
+                GUILayout.Space(5);
+                EditorGUILayout.HelpBox(s, MessageType.None);
+                GUILayout.Space(5);
+                EditorGUILayout.TextField("EditorGUIUtility.IconContent(\"" + _iconSelected.tooltip + "\")");
+                GUILayout.Space(5);
+                if (GUILayout.Button("Copy to clipboard", EditorStyles.miniButton))
+                    EditorGUIUtility.systemCopyBuffer = _iconSelected.tooltip;
+            }
+
+            GUILayout.Space(10);
+
+            if (GUILayout.Button("X", GUILayout.ExpandHeight(true)))
+            {
+                _iconSelected = null;
+            }
+        }
+    }
+
+    private static GUIContent _iconSelected;
+
+    //static GUIStyle iconBtnStyle = null;
+    private static List<GUIContent> _iconContentListAll;
+    private static List<GUIContent> _iconContentListSmall;
+    private static List<GUIContent> _iconContentListBig;
+    private static List<string> _iconMissingNames;
+    private static GUIStyle _iconButtonStyle;
+    private static GUIStyle _iconPreviewBlack;
+    private static GUIStyle _iconPreviewWhite;
+
+    private void AllTheTextures(ref GUIStyle s, Texture2D t)
+    {
+        s.hover.background = s.onHover.background = s.focused.background = s.onFocused.background = s.active.background = s.onActive.background = s.normal.background = s.onNormal.background = t;
+        s.hover.scaledBackgrounds = s.onHover.scaledBackgrounds = s.focused.scaledBackgrounds = s.onFocused.scaledBackgrounds =
+            s.active.scaledBackgrounds = s.onActive.scaledBackgrounds = s.normal.scaledBackgrounds = s.onNormal.scaledBackgrounds = new[] { t };
+    }
+
+    private Texture2D Texture2DPixel(Color c)
+    {
+        Texture2D t = new Texture2D(1, 1);
+        t.SetPixel(0, 0, c);
+        t.Apply();
+        return t;
+    }
+
+    private void InitIcons()
+    {
+        if (_iconContentListSmall != null) return;
+
+        _iconButtonStyle = new GUIStyle(EditorStyles.miniButton)
+        {
+            margin = new RectOffset(0, 0, 0, 0),
+            fixedHeight = 0
+        };
+
+        _iconPreviewBlack = new GUIStyle(_iconButtonStyle);
+        AllTheTextures(ref _iconPreviewBlack, Texture2DPixel(new Color(0.15f, 0.15f, 0.15f)));
+
+        _iconPreviewWhite = new GUIStyle(_iconButtonStyle);
+        AllTheTextures(ref _iconPreviewWhite, Texture2DPixel(new Color(0.85f, 0.85f, 0.85f)));
+
+        _iconMissingNames = new List<string>();
+        _iconContentListSmall = new List<GUIContent>();
+        _iconContentListBig = new List<GUIContent>();
+        _iconContentListAll = new List<GUIContent>();
+
+        foreach (var t in IcoList)
+        {
+            GUIContent ico = GetIcon(t);
+
+            if (ico == null)
+            {
+                _iconMissingNames.Add(t);
+                continue;
+            }
+
+            ico.tooltip = t;
+
+            _iconContentListAll.Add(ico);
+
+            if (!(ico.image.width <= 36 || ico.image.height <= 36))
+                _iconContentListBig.Add(ico);
+            else _iconContentListSmall.Add(ico);
+        }
+    }
+
+    // https://gist.github.com/MattRix/c1f7840ae2419d8eb2ec0695448d4321
+    // https://unitylist.com/p/5c3/Unity-editor-icons
+
+    #region ICONS
+
+    public static string[] IcoList =
+    {
+        "_Help", "_Popup", "aboutwindow.mainheader", "ageialogo", "AlphabeticalSorting", "Animation.AddEvent",
+        "Animation.AddKeyframe", "Animation.EventMarker", "Animation.FirstKey", "Animation.LastKey",
+        "Animation.NextKey", "Animation.Play", "Animation.PrevKey", "Animation.Record", "Animation.SequencerLink",
+        "animationanimated", "animationdopesheetkeyframe", "animationkeyframe", "animationnocurve",
+        "animationvisibilitytoggleoff", "animationvisibilitytoggleon", "AnimationWrapModeMenu", "AssemblyLock",
+        "Asset Store", "Audio Mixer", "AvatarCompass", "AvatarController.Layer", "AvatarController.LayerHover",
+        "AvatarController.LayerSelected", "BodyPartPicker", "BodySilhouette", "DotFill", "DotFrame", "DotFrameDotted",
+        "DotSelection", "Head", "HeadIk", "HeadZoom", "HeadZoomSilhouette", "LeftArm", "LeftFeetIk", "LeftFingers",
+        "LeftFingersIk", "LeftHandZoom", "LeftHandZoomSilhouette", "LeftLeg", "MaskEditor_Root", "RightArm", "RightFeetIk",
+        "RightFingers", "RightFingersIk", "RightHandZoom", "RightHandZoomSilhouette", "RightLeg", "Torso", "AvatarPivot",
+        "back", "back@2x", "beginButton-On", "beginButton", "blendKey", "blendKeyOverlay", "blendKeySelected",
+        "blendSampler", "blueGroove", "BuildSettings.Android", "BuildSettings.Android.Small", "BuildSettings.Broadcom",
+        "BuildSettings.Editor", "BuildSettings.Editor.Small", "BuildSettings.Facebook",
+        "BuildSettings.Facebook.Small", "BuildSettings.FlashPlayer", "BuildSettings.FlashPlayer.Small",
+        "BuildSettings.iPhone", "BuildSettings.iPhone.Small", "BuildSettings.Lumin", "BuildSettings.Lumin.small",
+        "BuildSettings.Metro", "BuildSettings.Metro.Small", "BuildSettings.N3DS", "BuildSettings.N3DS.Small",
+        "BuildSettings.PS4", "BuildSettings.PS4.Small", "BuildSettings.PSM", "BuildSettings.PSM.Small",
+        "BuildSettings.PSP2", "BuildSettings.PSP2.Small", "BuildSettings.SelectedIcon", "BuildSettings.Standalone",
+        "BuildSettings.Standalone.Small", "BuildSettings.StandaloneBroadcom.Small",
+        "BuildSettings.StandaloneGLES20Emu.Small", "BuildSettings.StandaloneGLESEmu",
+        "BuildSettings.StandaloneGLESEmu.Small", "BuildSettings.Switch", "BuildSettings.Switch.Small",
+        "BuildSettings.tvOS", "BuildSettings.tvOS.Small", "BuildSettings.Web", "BuildSettings.Web.Small",
+        "BuildSettings.WebGL", "BuildSettings.WebGL.Small", "BuildSettings.WP8", "BuildSettings.WP8.Small",
+        "BuildSettings.Xbox360", "BuildSettings.Xbox360.Small", "BuildSettings.XboxOne",
+        "BuildSettings.XboxOne.Small", "BuildSettings.Xiaomi", "Camera Gizmo", "CheckerFloor", "Clipboard",
+        "ClothInspector.PaintTool", "ClothInspector.PaintValue", "ClothInspector.SelectTool",
+        "ClothInspector.SettingsTool", "ClothInspector.ViewValue", "CloudConnect", "Collab.Build",
+        "Collab.BuildFailed", "Collab.BuildSucceeded", "Collab.FileAdded", "Collab.FileConflict", "Collab.FileDeleted",
+        "Collab.FileIgnored", "Collab.FileMoved", "Collab.FileUpdated", "Collab.FolderAdded", "Collab.FolderConflict",
+        "Collab.FolderDeleted", "Collab.FolderIgnored", "Collab.FolderMoved", "Collab.FolderUpdated",
+        "Collab.NoInternet", "Collab", "Collab.Warning", "CollabConflict", "CollabError", "CollabNew", "CollabOffline",
+        "CollabProgress", "CollabPull", "CollabPush", "ColorPicker.ColorCycle", "ColorPicker.CycleColor",
+        "ColorPicker.CycleSlider", "ColorPicker.SliderCycle", "console.erroricon.inactive.sml", "console.erroricon",
+        "console.erroricon.sml", "console.infoicon", "console.infoicon.sml", "console.warnicon.inactive.sml",
+        "console.warnicon", "console.warnicon.sml", "curvekeyframe", "curvekeyframeselected",
+        "curvekeyframeselectedoverlay", "curvekeyframesemiselectedoverlay", "curvekeyframeweighted", "CustomSorting",
+        "d__Popup", "d_aboutwindow.mainheader", "d_ageialogo", "d_AlphabeticalSorting", "d_Animation.AddEvent",
+        "d_Animation.AddKeyframe", "d_Animation.EventMarker", "d_Animation.FirstKey", "d_Animation.LastKey",
+        "d_Animation.NextKey", "d_Animation.Play", "d_Animation.PrevKey", "d_Animation.Record",
+        "d_Animation.SequencerLink", "d_animationanimated", "d_animationkeyframe", "d_animationnocurve",
+        "d_animationvisibilitytoggleoff", "d_animationvisibilitytoggleon", "d_AnimationWrapModeMenu",
+        "d_AS Badge Delete", "d_AS Badge New", "d_AssemblyLock", "d_Asset Store", "d_Audio Mixer",
+        "d_AvatarBlendBackground", "d_AvatarBlendLeft", "d_AvatarBlendLeftA", "d_AvatarBlendRight",
+        "d_AvatarBlendRightA", "d_AvatarCompass", "d_AvatarPivot", "d_back", "d_back@2x", "d_beginButton-On",
+        "d_beginButton", "d_blueGroove", "d_BuildSettings.Android", "d_BuildSettings.Android.Small",
+        "d_BuildSettings.Broadcom", "d_BuildSettings.FlashPlayer", "d_BuildSettings.FlashPlayer.Small",
+        "d_BuildSettings.iPhone", "d_BuildSettings.iPhone.Small", "d_BuildSettings.Lumin",
+        "d_BuildSettings.Lumin.small", "d_BuildSettings.PS4", "d_BuildSettings.PS4.Small", "d_BuildSettings.PSP2",
+        "d_BuildSettings.PSP2.Small", "d_BuildSettings.SelectedIcon", "d_BuildSettings.Standalone",
+        "d_BuildSettings.Standalone.Small", "d_BuildSettings.tvOS", "d_BuildSettings.tvOS.Small",
+        "d_BuildSettings.Web", "d_BuildSettings.Web.Small", "d_BuildSettings.WebGL", "d_BuildSettings.WebGL.Small",
+        "d_BuildSettings.Xbox360", "d_BuildSettings.Xbox360.Small", "d_BuildSettings.XboxOne",
+        "d_BuildSettings.XboxOne.Small", "d_CheckerFloor", "d_CloudConnect", "d_Collab.FileAdded",
+        "d_Collab.FileConflict", "d_Collab.FileDeleted", "d_Collab.FileIgnored", "d_Collab.FileMoved",
+        "d_Collab.FileUpdated", "d_Collab.FolderAdded", "d_Collab.FolderConflict", "d_Collab.FolderDeleted",
+        "d_Collab.FolderIgnored", "d_Collab.FolderMoved", "d_Collab.FolderUpdated", "d_ColorPicker.CycleColor",
+        "d_ColorPicker.CycleSlider", "d_console.erroricon", "d_console.erroricon.sml", "d_console.infoicon",
+        "d_console.infoicon.sml", "d_console.warnicon", "d_console.warnicon.sml", "d_curvekeyframe",
+        "d_curvekeyframeselected", "d_curvekeyframeselectedoverlay", "d_curvekeyframesemiselectedoverlay",
+        "d_curvekeyframeweighted", "d_CustomSorting", "d_DefaultSorting", "d_EditCollider", "d_editcollision_16",
+        "d_editconstraints_16", "d_editicon.sml", "d_endButton-On", "d_endButton", "d_eyeDropper.Large",
+        "d_eyeDropper.sml", "d_Favorite", "d_FilterByLabel", "d_FilterByType", "d_FilterSelectedOnly",
+        "d_FilterSelectedOnly@2x", "d_forward", "d_forward@2x", "d_GEAR", "d_Groove", "d_HorizontalSplit",
+        "d_icon dropdown", "d_InspectorLock", "d_JointAngularLimits", "d_leftBracket", "d_Lighting",
+        "d_LightmapEditor.WindowTitle", "d_LookDevCenterLight", "d_LookDevCenterLight@2x", "d_LookDevClose",
+        "d_LookDevClose@2x", "d_LookDevEnvRotation", "d_LookDevEnvRotation@2x", "d_LookDevMirrorViews",
+        "d_LookDevMirrorViews@2x", "d_LookDevMirrorViewsActive", "d_LookDevMirrorViewsActive@2x",
+        "d_LookDevMirrorViewsInactive", "d_LookDevMirrorViewsInactive@2x", "d_LookDevObjRotation",
+        "d_LookDevObjRotation@2x", "d_LookDevPaneOption", "d_LookDevPaneOption@2x", "d_LookDevResetEnv",
+        "d_LookDevResetEnv@2x", "d_LookDevShadow", "d_LookDevShadow@2x", "d_LookDevSideBySide",
+        "d_LookDevSideBySide@2x", "d_LookDevSingle1", "d_LookDevSingle1@2x", "d_LookDevSingle2",
+        "d_LookDevSingle2@2x", "d_LookDevSplit", "d_LookDevSplit@2x", "d_LookDevZone", "d_LookDevZone@2x",
+        "d_Mirror", "d_model large", "d_monologo", "d_MoveTool on", "d_MoveTool", "d_Navigation", "d_Occlusion",
+        "d_P4_AddedLocal", "d_P4_AddedRemote", "d_P4_CheckOutLocal", "d_P4_CheckOutRemote", "d_P4_Conflicted",
+        "d_P4_DeletedLocal", "d_P4_DeletedRemote", "d_P4_Local", "d_P4_LockedLocal", "d_P4_LockedRemote",
+        "d_P4_OutOfSync", "d_Particle Effect", "d_PauseButton On", "d_PauseButton", "d_PlayButton On", "d_PlayButton",
+        "d_PlayButtonProfile On", "d_PlayButtonProfile", "d_playLoopOff", "d_playLoopOn", "d_preAudioAutoPlayOff",
+        "d_preAudioAutoPlayOn", "d_preAudioLoopOff", "d_preAudioLoopOn", "d_preAudioPlayOff", "d_preAudioPlayOn",
+        "d_PreMatCube", "d_PreMatCylinder", "d_PreMatLight0", "d_PreMatLight1", "d_PreMatSphere", "d_PreMatTorus",
+        "d_Preset.Context", "d_PreTextureAlpha", "d_PreTextureMipMapHigh", "d_PreTextureMipMapLow", "d_PreTextureRGB",
+        "d_Profiler.Audio", "d_Profiler.CPU", "d_Profiler.FirstFrame", "d_Profiler.GPU", "d_Profiler.LastFrame",
+        "d_Profiler.Memory", "d_Profiler.Network", "d_Profiler.NextFrame", "d_Profiler.Physics", "d_Profiler.PrevFrame",
+        "d_Profiler.Record", "d_Profiler.Rendering", "d_Profiler.Video", "d_ProfilerColumn.WarningCount", "d_Project",
+        "d_RectTool On", "d_RectTool", "d_RectTransformBlueprint", "d_RectTransformRaw", "d_redGroove", "d_Refresh",
+        "d_renderdoc", "d_rightBracket", "d_RotateTool On", "d_RotateTool", "d_ScaleTool On", "d_ScaleTool",
+        "d_SceneViewAlpha", "d_SceneViewAudio", "d_SceneViewFx", "d_SceneViewLighting", "d_SceneViewOrtho",
+        "d_SceneViewRGB", "d_ScrollShadow", "d_Settings", "d_SettingsIcon", "d_SocialNetworks.FacebookShare",
+        "d_SocialNetworks.LinkedInShare", "d_SocialNetworks.Tweet", "d_SocialNetworks.UDNOpen", "d_SpeedScale",
+        "d_StepButton On", "d_StepButton", "d_StepLeftButton-On", "d_StepLeftButton", "d_SVN_AddedLocal",
+        "d_SVN_Conflicted", "d_SVN_DeletedLocal", "d_SVN_Local", "d_SVN_LockedLocal", "d_SVN_OutOfSync", "d_tab_next",
+        "d_tab_next@2x", "d_tab_prev", "d_tab_prev@2x", "d_TerrainInspector.TerrainToolLower On",
+        "d_TerrainInspector.TerrainToolLowerAlt", "d_TerrainInspector.TerrainToolPlants On",
+        "d_TerrainInspector.TerrainToolPlants", "d_TerrainInspector.TerrainToolPlantsAlt On",
+        "d_TerrainInspector.TerrainToolPlantsAlt", "d_TerrainInspector.TerrainToolRaise On",
+        "d_TerrainInspector.TerrainToolRaise", "d_TerrainInspector.TerrainToolSetheight On",
+        "d_TerrainInspector.TerrainToolSetheight", "d_TerrainInspector.TerrainToolSetheightAlt On",
+        "d_TerrainInspector.TerrainToolSetheightAlt", "d_TerrainInspector.TerrainToolSettings On",
+        "d_TerrainInspector.TerrainToolSettings", "d_TerrainInspector.TerrainToolSmoothHeight On",
+        "d_TerrainInspector.TerrainToolSmoothHeight", "d_TerrainInspector.TerrainToolSplat On",
+        "d_TerrainInspector.TerrainToolSplat", "d_TerrainInspector.TerrainToolSplatAlt On",
+        "d_TerrainInspector.TerrainToolSplatAlt", "d_TerrainInspector.TerrainToolTrees On",
+        "d_TerrainInspector.TerrainToolTrees", "d_TerrainInspector.TerrainToolTreesAlt On",
+        "d_TerrainInspector.TerrainToolTreesAlt", "d_TimelineDigIn", "d_TimelineEditModeMixOFF",
+        "d_TimelineEditModeMixON", "d_TimelineEditModeReplaceOFF", "d_TimelineEditModeReplaceON",
+        "d_TimelineEditModeRippleOFF", "d_TimelineEditModeRippleON", "d_TimelineSelector", "d_Toolbar Minus",
+        "d_Toolbar Plus More", "d_Toolbar Plus", "d_ToolHandleCenter", "d_ToolHandleGlobal", "d_ToolHandleLocal",
+        "d_ToolHandlePivot", "d_tranp", "d_TransformTool On", "d_TransformTool", "d_tree_icon", "d_tree_icon_branch",
+        "d_tree_icon_branch_frond", "d_tree_icon_frond", "d_tree_icon_leaf", "d_TreeEditor.AddBranches",
+        "d_TreeEditor.AddLeaves", "d_TreeEditor.Branch On", "d_TreeEditor.Branch", "d_TreeEditor.BranchFreeHand On",
+        "d_TreeEditor.BranchFreeHand", "d_TreeEditor.BranchRotate On", "d_TreeEditor.BranchRotate",
+        "d_TreeEditor.BranchScale On", "d_TreeEditor.BranchScale", "d_TreeEditor.BranchTranslate On",
+        "d_TreeEditor.BranchTranslate", "d_TreeEditor.Distribution On", "d_TreeEditor.Distribution",
+        "d_TreeEditor.Duplicate", "d_TreeEditor.Geometry On", "d_TreeEditor.Geometry", "d_TreeEditor.Leaf On",
+        "d_TreeEditor.Leaf", "d_TreeEditor.LeafFreeHand On", "d_TreeEditor.LeafFreeHand", "d_TreeEditor.LeafRotate On",
+        "d_TreeEditor.LeafRotate", "d_TreeEditor.LeafScale On", "d_TreeEditor.LeafScale",
+        "d_TreeEditor.LeafTranslate On", "d_TreeEditor.LeafTranslate", "d_TreeEditor.Material On",
+        "d_TreeEditor.Material", "d_TreeEditor.Refresh", "d_TreeEditor.Trash", "d_TreeEditor.Wind On",
+        "d_TreeEditor.Wind", "d_UnityEditor.AnimationWindow", "d_UnityEditor.ConsoleWindow",
+        "d_UnityEditor.DebugInspectorWindow", "d_UnityEditor.FindDependencies", "d_UnityEditor.GameView",
+        "d_UnityEditor.HierarchyWindow", "d_UnityEditor.InspectorWindow", "d_UnityEditor.LookDevView",
+        "d_UnityEditor.ProfilerWindow", "d_UnityEditor.SceneHierarchyWindow", "d_UnityEditor.SceneView",
+        "d_UnityEditor.Timeline.TimelineWindow", "d_UnityEditor.VersionControl", "d_UnityLogo", "d_VerticalSplit",
+        "d_ViewToolMove On", "d_ViewToolMove", "d_ViewToolOrbit On", "d_ViewToolOrbit", "d_ViewToolZoom On",
+        "d_ViewToolZoom", "d_VisibilityOff", "d_VisibilityOn", "d_VUMeterTextureHorizontal", "d_VUMeterTextureVertical",
+        "d_WaitSpin00", "d_WaitSpin01", "d_WaitSpin02", "d_WaitSpin03", "d_WaitSpin04", "d_WaitSpin05", "d_WaitSpin06",
+        "d_WaitSpin07", "d_WaitSpin08", "d_WaitSpin09", "d_WaitSpin10", "d_WaitSpin11", "d_WelcomeScreen.AssetStoreLogo",
+        "d_winbtn_graph", "d_winbtn_graph_close_h", "d_winbtn_graph_max_h", "d_winbtn_graph_min_h",
+        "d_winbtn_mac_close", "d_winbtn_mac_close_a", "d_winbtn_mac_close_h", "d_winbtn_mac_inact", "d_winbtn_mac_max",
+        "d_winbtn_mac_max_a", "d_winbtn_mac_max_h", "d_winbtn_mac_min", "d_winbtn_mac_min_a", "d_winbtn_mac_min_h",
+        "d_winbtn_win_close", "d_winbtn_win_close_a", "d_winbtn_win_close_h", "d_winbtn_win_max", "d_winbtn_win_max_a",
+        "d_winbtn_win_max_h", "d_winbtn_win_min", "d_winbtn_win_min_a", "d_winbtn_win_min_h", "d_winbtn_win_rest",
+        "d_winbtn_win_rest_a", "d_winbtn_win_rest_h", "DefaultSorting", "EditCollider", "editcollision_16",
+        "editconstraints_16", "editicon.sml", "endButton-On", "endButton", "eyeDropper.Large", "eyeDropper.sml",
+        "Favorite", "FilterByLabel", "FilterByType", "FilterSelectedOnly", "FilterSelectedOnly@2x", "forward",
+        "forward@2x", "GEAR", "Grid.BoxTool", "Grid.Default", "Grid.EraserTool", "Grid.FillTool", "Grid.MoveTool",
+        "Grid.PaintTool", "Grid.PickingTool", "Grid.SelectTool", "Groove", "align_horizontally",
+        "align_horizontally_center", "align_horizontally_center_active", "align_horizontally_left",
+        "align_horizontally_left_active", "align_horizontally_right", "align_horizontally_right_active",
+        "align_vertically", "align_vertically_bottom", "align_vertically_bottom_active", "align_vertically_center",
+        "align_vertically_center_active", "align_vertically_top", "align_vertically_top_active",
+        "d_align_horizontally", "d_align_horizontally_center", "d_align_horizontally_center_active",
+        "d_align_horizontally_left", "d_align_horizontally_left_active", "d_align_horizontally_right",
+        "d_align_horizontally_right_active", "d_align_vertically", "d_align_vertically_bottom",
+        "d_align_vertically_bottom_active", "d_align_vertically_center", "d_align_vertically_center_active",
+        "d_align_vertically_top", "d_align_vertically_top_active", "HorizontalSplit", "icon dropdown",
+        "InspectorLock", "JointAngularLimits", "KnobCShape", "KnobCShapeMini", "leftBracket", "Lighting",
+        "LightmapEditor.WindowTitle", "Lightmapping", "d_greenLight", "d_lightOff", "d_lightRim", "d_orangeLight",
+        "d_redLight", "greenLight", "lightOff", "lightRim", "orangeLight", "redLight", "LockIcon-On", "LockIcon",
+        "LookDevCenterLight", "LookDevCenterLightl@2x", "LookDevClose", "LookDevClose@2x", "LookDevEnvRotation",
+        "LookDevEnvRotation@2x", "LookDevEyedrop", "LookDevLight", "LookDevLight@2x", "LookDevMirrorViewsActive",
+        "LookDevMirrorViewsActive@2x", "LookDevMirrorViewsInactive", "LookDevMirrorViewsInactive@2x",
+        "LookDevObjRotation", "LookDevObjRotation@2x", "LookDevPaneOption", "LookDevPaneOption@2x", "LookDevResetEnv",
+        "LookDevResetEnv@2x", "LookDevShadow", "LookDevShadow@2x", "LookDevShadowFrame", "LookDevShadowFrame@2x",
+        "LookDevSideBySide", "LookDevSideBySide@2x", "LookDevSingle1", "LookDevSingle1@2x", "LookDevSingle2",
+        "LookDevSingle2@2x", "LookDevSplit", "LookDevSplit@2x", "LookDevZone", "LookDevZone@2x", "loop", "Mirror",
+        "monologo", "MoveTool on", "MoveTool", "Navigation", "Occlusion", "P4_AddedLocal", "P4_AddedRemote",
+        "P4_BlueLeftParenthesis", "P4_BlueRightParenthesis", "P4_CheckOutLocal", "P4_CheckOutRemote", "P4_Conflicted",
+        "P4_DeletedLocal", "P4_DeletedRemote", "P4_Local", "P4_LockedLocal", "P4_LockedRemote", "P4_OutOfSync",
+        "P4_RedLeftParenthesis", "P4_RedRightParenthesis", "P4_Updating", "PackageBadgeDelete", "PackageBadgeNew",
+        "Particle Effect", "PauseButton On", "PauseButton", "PlayButton On", "PlayButton", "PlayButtonProfile On",
+        "PlayButtonProfile", "playLoopOff", "playLoopOn", "playSpeed", "preAudioAutoPlayOff", "preAudioAutoPlayOn",
+        "preAudioLoopOff", "preAudioLoopOn", "preAudioPlayOff", "preAudioPlayOn", "PreMatCube", "PreMatCylinder",
+        "PreMatLight0", "PreMatLight1", "PreMatQuad", "PreMatSphere", "PreMatTorus", "Preset.Context", "PreTextureAlpha",
+        "PreTextureArrayFirstSlice", "PreTextureArrayLastSlice", "PreTextureMipMapHigh", "PreTextureMipMapLow",
+        "PreTextureRGB", "AreaLight Gizmo", "AreaLight Icon", "Assembly Icon", "AssetStore Icon", "AudioMixerView Icon",
+        "AudioSource Gizmo", "Camera Gizmo", "CGProgram Icon", "ChorusFilter Icon", "CollabChanges Icon",
+        "CollabChangesConflict Icon", "CollabChangesDeleted Icon", "CollabConflict Icon", "CollabCreate Icon",
+        "CollabDeleted Icon", "CollabEdit Icon", "CollabExclude Icon", "CollabMoved Icon", "cs Script Icon",
+        "d_AudioMixerView Icon", "d_CollabChanges Icon", "d_CollabChangesConflict Icon", "d_CollabChangesDeleted Icon",
+        "d_CollabConflict Icon", "d_CollabCreate Icon", "d_CollabDeleted Icon", "d_CollabEdit Icon",
+        "d_CollabExclude Icon", "d_CollabMoved Icon", "d_GridLayoutGroup Icon", "d_HorizontalLayoutGroup Icon",
+        "d_Prefab Icon", "d_PrefabModel Icon", "d_PrefabVariant Icon", "d_VerticalLayoutGroup Icon",
+        "DefaultSlate Icon", "DirectionalLight Gizmo", "DirectionalLight Icon", "DiscLight Gizmo", "DiscLight Icon",
+        "dll Script Icon", "EchoFilter Icon", "Favorite Icon", "Folder Icon", "FolderEmpty Icon",
+        "FolderFavorite Icon", "GameManager Icon", "GridBrush Icon", "HighPassFilter Icon",
+        "HorizontalLayoutGroup Icon", "LensFlare Gizmo", "LightingDataAssetParent Icon", "LightProbeGroup Gizmo",
+        "LightProbeProxyVolume Gizmo", "LowPassFilter Icon", "Main Light Gizmo", "MetaFile Icon",
+        "Microphone Icon", "MuscleClip Icon", "ParticleSystem Gizmo", "PointLight Gizmo", "Prefab Icon",
+        "PrefabModel Icon", "PrefabOverlayAdded Icon", "PrefabOverlayModified Icon", "PrefabOverlayRemoved Icon",
+        "PrefabVariant Icon", "Projector Gizmo", "RaycastCollider Icon", "ReflectionProbe Gizmo",
+        "ReverbFilter Icon", "SceneSet Icon", "Search Icon", "SoftlockProjectBrowser Icon", "SpeedTreeModel Icon",
+        "SpotLight Gizmo", "Spotlight Icon", "SpriteCollider Icon", "sv_icon_dot0_pix16_gizmo",
+        "sv_icon_dot10_pix16_gizmo", "sv_icon_dot11_pix16_gizmo", "sv_icon_dot12_pix16_gizmo",
+        "sv_icon_dot13_pix16_gizmo", "sv_icon_dot14_pix16_gizmo", "sv_icon_dot15_pix16_gizmo",
+        "sv_icon_dot1_pix16_gizmo", "sv_icon_dot2_pix16_gizmo", "sv_icon_dot3_pix16_gizmo",
+        "sv_icon_dot4_pix16_gizmo", "sv_icon_dot5_pix16_gizmo", "sv_icon_dot6_pix16_gizmo",
+        "sv_icon_dot7_pix16_gizmo", "sv_icon_dot8_pix16_gizmo", "sv_icon_dot9_pix16_gizmo",
+        "AnimatorController Icon", "AnimatorState Icon", "AnimatorStateMachine Icon",
+        "AnimatorStateTransition Icon", "BlendTree Icon", "AnimationWindowEvent Icon", "AudioMixerController Icon",
+        "DefaultAsset Icon", "EditorSettings Icon", "AnyStateNode Icon", "HumanTemplate Icon",
+        "LightingDataAsset Icon", "LightmapParameters Icon", "Preset Icon", "SceneAsset Icon",
+        "SubstanceArchive Icon", "AssemblyDefinitionAsset Icon", "NavMeshAgent Icon", "NavMeshData Icon",
+        "NavMeshObstacle Icon", "OffMeshLink Icon", "AnalyticsTracker Icon", "Animation Icon",
+        "AnimationClip Icon", "AimConstraint Icon", "d_AimConstraint Icon", "d_LookAtConstraint Icon",
+        "d_ParentConstraint Icon", "d_PositionConstraint Icon", "d_RotationConstraint Icon",
+        "d_ScaleConstraint Icon", "LookAtConstraint Icon", "ParentConstraint Icon", "PositionConstraint Icon",
+        "RotationConstraint Icon", "ScaleConstraint Icon", "Animator Icon", "AnimatorOverrideController Icon",
+        "AreaEffector2D Icon", "AudioMixerGroup Icon", "AudioMixerSnapshot Icon", "AudioSpatializerMicrosoft Icon",
+        "AudioChorusFilter Icon", "AudioClip Icon", "AudioDistortionFilter Icon", "AudioEchoFilter Icon",
+        "AudioHighPassFilter Icon", "AudioListener Icon", "AudioLowPassFilter Icon", "AudioReverbFilter Icon",
+        "AudioReverbZone Icon", "AudioSource Icon", "Avatar Icon", "AvatarMask Icon", "BillboardAsset Icon",
+        "BillboardRenderer Icon", "BoxCollider Icon", "BoxCollider2D Icon", "BuoyancyEffector2D Icon", "Camera Icon",
+        "Canvas Icon", "CanvasGroup Icon", "CanvasRenderer Icon", "CapsuleCollider Icon", "CapsuleCollider2D Icon",
+        "CharacterController Icon", "CharacterJoint Icon", "CircleCollider2D Icon", "Cloth Icon",
+        "CompositeCollider2D Icon", "ComputeShader Icon", "ConfigurableJoint Icon", "ConstantForce Icon",
+        "ConstantForce2D Icon", "Cubemap Icon", "d_Canvas Icon", "d_CanvasGroup Icon", "d_CanvasRenderer Icon",
+        "d_GameObject Icon", "d_LightProbeProxyVolume Icon", "d_ParticleSystem Icon", "d_ParticleSystemForceField Icon",
+        "d_RectTransform Icon", "d_StreamingController Icon", "DistanceJoint2D Icon", "EdgeCollider2D Icon",
+        "d_EventSystem Icon", "d_EventTrigger Icon", "d_Physics2DRaycaster Icon", "d_PhysicsRaycaster Icon",
+        "d_StandaloneInputModule Icon", "d_TouchInputModule Icon", "EventSystem Icon", "EventTrigger Icon",
+        "HoloLensInputModule Icon", "Physics2DRaycaster Icon", "PhysicsRaycaster Icon", "StandaloneInputModule Icon",
+        "TouchInputModule Icon", "SpriteShapeRenderer Icon", "VisualTreeAsset Icon", "d_VisualEffect Icon",
+        "d_VisualEffectAsset Icon", "VisualEffect Icon", "VisualEffectAsset Icon", "FixedJoint Icon",
+        "FixedJoint2D Icon", "Flare Icon", "FlareLayer Icon", "Font Icon", "FrictionJoint2D Icon",
+        "GameObject Icon", "Grid Icon", "GUILayer Icon", "GUISkin Icon", "GUIText Icon", "GUITexture Icon",
+        "Halo Icon", "HingeJoint Icon", "HingeJoint2D Icon", "LensFlare Icon", "Light Icon", "LightProbeGroup Icon",
+        "LightProbeProxyVolume Icon", "LightProbes Icon", "LineRenderer Icon", "LODGroup Icon", "Material Icon",
+        "Mesh Icon", "MeshCollider Icon", "MeshFilter Icon", "MeshRenderer Icon", "Motion Icon", "MovieTexture Icon",
+        "NetworkAnimator Icon", "NetworkDiscovery Icon", "NetworkIdentity Icon", "NetworkLobbyManager Icon",
+        "NetworkLobbyPlayer Icon", "NetworkManager Icon", "NetworkManagerHUD Icon", "NetworkMigrationManager Icon",
+        "NetworkProximityChecker Icon", "NetworkStartPosition Icon", "NetworkTransform Icon",
+        "NetworkTransformChild Icon", "NetworkTransformVisualizer Icon", "NetworkView Icon", "OcclusionArea Icon",
+        "OcclusionPortal Icon", "ParticleSystem Icon", "ParticleSystemForceField Icon", "PhysicMaterial Icon",
+        "PhysicsMaterial2D Icon", "PlatformEffector2D Icon", "d_PlayableDirector Icon", "PlayableDirector Icon",
+        "PointEffector2D Icon", "PolygonCollider2D Icon", "ProceduralMaterial Icon", "Projector Icon",
+        "RectTransform Icon", "ReflectionProbe Icon", "RelativeJoint2D Icon", "d_SortingGroup Icon",
+        "SortingGroup Icon", "RenderTexture Icon", "Rigidbody Icon", "Rigidbody2D Icon", "ScriptableObject Icon",
+        "Shader Icon", "ShaderVariantCollection Icon", "SkinnedMeshRenderer Icon", "Skybox Icon", "SliderJoint2D Icon",
+        "TrackedPoseDriver Icon", "SphereCollider Icon", "SpringJoint Icon", "SpringJoint2D Icon", "Sprite Icon",
+        "SpriteMask Icon", "SpriteRenderer Icon", "StreamingController Icon", "StyleSheet Icon", "SurfaceEffector2D Icon",
+        "TargetJoint2D Icon", "Terrain Icon", "TerrainCollider Icon", "TerrainData Icon", "TextAsset Icon",
+        "TextMesh Icon", "Texture Icon", "Texture2D Icon", "Tile Icon", "Tilemap Icon", "TilemapCollider2D Icon",
+        "TilemapRenderer Icon", "d_TimelineAsset Icon", "TimelineAsset Icon", "TrailRenderer Icon", "Transform Icon",
+        "SpriteAtlas Icon", "AspectRatioFitter Icon", "Button Icon", "CanvasScaler Icon", "ContentSizeFitter Icon",
+        "d_AspectRatioFitter Icon", "d_CanvasScaler Icon", "d_ContentSizeFitter Icon", "d_FreeformLayoutGroup Icon",
+        "d_GraphicRaycaster Icon", "d_GridLayoutGroup Icon", "d_HorizontalLayoutGroup Icon", "d_LayoutElement Icon",
+        "d_PhysicalResolution Icon", "d_ScrollViewArea Icon", "d_SelectionList Icon", "d_SelectionListItem Icon",
+        "d_SelectionListTemplate Icon", "d_VerticalLayoutGroup Icon", "Dropdown Icon", "FreeformLayoutGroup Icon",
+        "GraphicRaycaster Icon", "GridLayoutGroup Icon", "HorizontalLayoutGroup Icon", "Image Icon", "InputField Icon",
+        "LayoutElement Icon", "Mask Icon", "Outline Icon", "PositionAsUV1 Icon", "RawImage Icon", "RectMask2D Icon",
+        "Scrollbar Icon", "ScrollRect Icon", "Selectable Icon", "Shadow Icon", "Slider Icon", "Text Icon", "Toggle Icon",
+        "ToggleGroup Icon", "VerticalLayoutGroup Icon", "VideoClip Icon", "VideoPlayer Icon", "VisualEffect Icon",
+        "VisualEffectAsset Icon", "WheelCollider Icon", "WheelJoint2D Icon", "WindZone Icon",
+        "SpatialMappingCollider Icon", "SpatialMappingRenderer Icon", "WorldAnchor Icon", "UssScript Icon",
+        "UxmlScript Icon", "VerticalLayoutGroup Icon", "VideoEffect Icon", "VisualEffect Gizmo",
+        "VisualEffectAsset Icon", "AnchorBehaviour Icon", "AnchorInputListenerBehaviour Icon",
+        "AnchorStageBehaviour Icon", "CloudRecoBehaviour Icon", "ContentPlacementBehaviour Icon",
+        "ContentPositioningBehaviour Icon", "CylinderTargetBehaviour Icon", "d_AnchorBehaviour Icon",
+        "d_AnchorInputListenerBehaviour Icon", "d_AnchorStageBehaviour Icon", "d_CloudRecoBehaviour Icon",
+        "d_ContentPlacementBehaviour Icon", "d_ContentPositioningBehaviour Icon", "d_CylinderTargetBehaviour Icon",
+        "d_ImageTargetBehaviour Icon", "d_MidAirPositionerBehaviour Icon", "d_ModelTargetBehaviour Icon",
+        "d_MultiTargetBehaviour Icon", "d_ObjectTargetBehaviour Icon", "d_PlaneFinderBehaviour Icon",
+        "d_UserDefinedTargetBuildingBehaviour Icon", "d_VirtualButtonBehaviour Icon", "d_VuforiaBehaviour Icon",
+        "d_VuMarkBehaviour Icon", "d_WireframeBehaviour Icon", "ImageTargetBehaviour Icon",
+        "MidAirPositionerBehaviour Icon", "ModelTargetBehaviour Icon", "MultiTargetBehaviour Icon",
+        "ObjectTargetBehaviour Icon", "PlaneFinderBehaviour Icon", "UserDefinedTargetBuildingBehaviour Icon",
+        "VirtualButtonBehaviour Icon", "VuforiaBehaviour Icon", "VuMarkBehaviour Icon", "WireframeBehaviour Icon",
+        "WindZone Gizmo", "Profiler.Audio", "Profiler.CPU", "Profiler.FirstFrame", "Profiler.GlobalIllumination",
+        "Profiler.GPU", "Profiler.Instrumentation", "Profiler.LastFrame", "Profiler.Memory", "Profiler.NetworkMessages",
+        "Profiler.NetworkOperations", "Profiler.NextFrame", "Profiler.Physics", "Profiler.Physics2D",
+        "Profiler.PrevFrame", "Profiler.Record", "Profiler.Rendering", "Profiler.UI", "Profiler.UIDetails",
+        "Profiler.Video", "ProfilerColumn.WarningCount", "Project", "RectTool On", "RectTool", "RectTransformBlueprint",
+        "RectTransformRaw", "redGroove", "Refresh", "renderdoc", "rightBracket", "RotateTool On", "RotateTool",
+        "SaveActive", "SaveFromPlay", "SavePassive", "ScaleTool On", "ScaleTool", "SceneLoadIn", "SceneLoadOut",
+        "SceneSave", "SceneSaveGrey", "SceneViewAlpha", "SceneViewAudio", "SceneViewFx", "SceneViewLighting",
+        "SceneViewOrtho", "SceneViewRGB", "ScrollShadow", "Settings", "SettingsIcon", "SocialNetworks.FacebookShare",
+        "SocialNetworks.LinkedInShare", "SocialNetworks.Tweet", "SocialNetworks.UDNLogo", "SocialNetworks.UDNOpen",
+        "SoftlockInline", "SpeedScale", "StateMachineEditor.ArrowTip", "StateMachineEditor.ArrowTipSelected",
+        "StateMachineEditor.Background", "StateMachineEditor.State", "StateMachineEditor.StateHover",
+        "StateMachineEditor.StateSelected", "StateMachineEditor.StateSub", "StateMachineEditor.StateSubHover",
+        "StateMachineEditor.StateSubSelected", "StateMachineEditor.UpButton", "StateMachineEditor.UpButtonHover",
+        "StepButton On", "StepButton", "StepLeftButton-On", "StepLeftButton", "sticky_arrow", "sticky_p4", "sticky_skin",
+        "sv_icon_dot0_sml", "sv_icon_dot10_sml", "sv_icon_dot11_sml", "sv_icon_dot12_sml", "sv_icon_dot13_sml",
+        "sv_icon_dot14_sml", "sv_icon_dot15_sml", "sv_icon_dot1_sml", "sv_icon_dot2_sml", "sv_icon_dot3_sml",
+        "sv_icon_dot4_sml", "sv_icon_dot5_sml", "sv_icon_dot6_sml", "sv_icon_dot7_sml", "sv_icon_dot8_sml",
+        "sv_icon_dot9_sml", "sv_icon_name0", "sv_icon_name1", "sv_icon_name2", "sv_icon_name3", "sv_icon_name4",
+        "sv_icon_name5", "sv_icon_name6", "sv_icon_name7", "sv_icon_none", "sv_label_0", "sv_label_1", "sv_label_2",
+        "sv_label_3", "sv_label_4", "sv_label_5", "sv_label_6", "sv_label_7", "SVN_AddedLocal", "SVN_Conflicted",
+        "SVN_DeletedLocal", "SVN_Local", "SVN_LockedLocal", "SVN_OutOfSync", "tab_next", "tab_next@2x", "tab_prev",
+        "tab_prev@2x", "TerrainInspector.TerrainToolLower On", "TerrainInspector.TerrainToolLower",
+        "TerrainInspector.TerrainToolLowerAlt", "TerrainInspector.TerrainToolPlants On",
+        "TerrainInspector.TerrainToolPlants", "TerrainInspector.TerrainToolPlantsAlt On",
+        "TerrainInspector.TerrainToolPlantsAlt", "TerrainInspector.TerrainToolRaise On",
+        "TerrainInspector.TerrainToolRaise", "TerrainInspector.TerrainToolSculpt On",
+        "TerrainInspector.TerrainToolSculpt", "TerrainInspector.TerrainToolSetheight On",
+        "TerrainInspector.TerrainToolSetheight", "TerrainInspector.TerrainToolSetheightAlt On",
+        "TerrainInspector.TerrainToolSetheightAlt", "TerrainInspector.TerrainToolSettings On",
+        "TerrainInspector.TerrainToolSettings", "TerrainInspector.TerrainToolSmoothHeight On",
+        "TerrainInspector.TerrainToolSmoothHeight", "TerrainInspector.TerrainToolSplat On",
+        "TerrainInspector.TerrainToolSplat", "TerrainInspector.TerrainToolSplatAlt On",
+        "TerrainInspector.TerrainToolSplatAlt", "TerrainInspector.TerrainToolTrees On",
+        "TerrainInspector.TerrainToolTrees", "TerrainInspector.TerrainToolTreesAlt On",
+        "TerrainInspector.TerrainToolTreesAlt", "TestFailed", "TestIgnored", "TestInconclusive", "TestNormal",
+        "TestPassed", "TestStopwatch", "TimelineClipBG", "TimelineClipFG", "TimelineDigIn", "TimelineEditModeMixOFF",
+        "TimelineEditModeMixON", "TimelineEditModeReplaceOFF", "TimelineEditModeReplaceON", "TimelineEditModeRippleOFF",
+        "TimelineEditModeRippleON", "TimelineSelector", "Toolbar Minus", "Toolbar Plus More", "Toolbar Plus",
+        "ToolHandleCenter", "ToolHandleGlobal", "ToolHandleLocal", "ToolHandlePivot", "tranp", "TransformTool On",
+        "TransformTool", "tree_icon", "tree_icon_branch", "tree_icon_branch_frond", "tree_icon_frond", "tree_icon_leaf",
+        "TreeEditor.AddBranches", "TreeEditor.AddLeaves", "TreeEditor.Branch On", "TreeEditor.Branch",
+        "TreeEditor.BranchFreeHand On", "TreeEditor.BranchFreeHand", "TreeEditor.BranchRotate On",
+        "TreeEditor.BranchRotate", "TreeEditor.BranchScale On", "TreeEditor.BranchScale",
+        "TreeEditor.BranchTranslate On", "TreeEditor.BranchTranslate", "TreeEditor.Distribution On",
+        "TreeEditor.Distribution", "TreeEditor.Duplicate", "TreeEditor.Geometry On", "TreeEditor.Geometry",
+        "TreeEditor.Leaf On", "TreeEditor.Leaf", "TreeEditor.LeafFreeHand On", "TreeEditor.LeafFreeHand",
+        "TreeEditor.LeafRotate On", "TreeEditor.LeafRotate", "TreeEditor.LeafScale On", "TreeEditor.LeafScale",
+        "TreeEditor.LeafTranslate On", "TreeEditor.LeafTranslate", "TreeEditor.Material On", "TreeEditor.Material",
+        "TreeEditor.Refresh", "TreeEditor.Trash", "TreeEditor.Wind On", "TreeEditor.Wind", "UnityEditor.AnimationWindow",
+        "UnityEditor.ConsoleWindow", "UnityEditor.DebugInspectorWindow", "UnityEditor.FindDependencies",
+        "UnityEditor.GameView", "UnityEditor.Graphs.AnimatorControllerTool", "UnityEditor.HierarchyWindow",
+        "UnityEditor.InspectorWindow", "UnityEditor.LookDevView", "UnityEditor.ProfilerWindow",
+        "UnityEditor.SceneHierarchyWindow", "UnityEditor.SceneView", "UnityEditor.Timeline.TimelineWindow",
+        "UnityEditor.VersionControl", "UnityLogo", "UnityLogoLarge", "UpArrow", "vcs_add", "vcs_branch", "vcs_change",
+        "vcs_check", "vcs_delete", "vcs_document", "vcs_edit", "vcs_incoming", "vcs_integrate", "vcs_local", "vcs_lock",
+        "vcs_refresh", "vcs_sync", "vcs_unresolved", "vcs_update", "VerticalSplit", "ViewToolMove On", "ViewToolMove",
+        "ViewToolOrbit On", "ViewToolOrbit", "ViewToolZoom On", "ViewToolZoom", "VisibilityOff", "VisibilityOn",
+        "VisualEffect Gizmo", "VUMeterTextureHorizontal", "VUMeterTextureVertical", "WaitSpin00", "WaitSpin01",
+        "WaitSpin02", "WaitSpin03", "WaitSpin04", "WaitSpin05", "WaitSpin06", "WaitSpin07", "WaitSpin08", "WaitSpin09",
+        "WaitSpin10", "WaitSpin11", "WelcomeScreen.AssetStoreLogo", "winbtn_graph", "winbtn_graph_close_h",
+        "winbtn_graph_max_h", "winbtn_graph_min_h", "winbtn_mac_close", "winbtn_mac_close_a", "winbtn_mac_close_h",
+        "winbtn_mac_inact", "winbtn_mac_max", "winbtn_mac_max_a", "winbtn_mac_max_h", "winbtn_mac_min",
+        "winbtn_mac_min_a", "winbtn_mac_min_h", "winbtn_win_close", "winbtn_win_close_a", "winbtn_win_close_h",
+        "winbtn_win_max", "winbtn_win_max_a", "winbtn_win_max_h", "winbtn_win_min", "winbtn_win_min_a",
+        "winbtn_win_min_h", "winbtn_win_rest", "winbtn_win_rest_a", "winbtn_win_rest_h",
+        "AvatarInspector/RightFingersIk", "AvatarInspector/LeftFingersIk", "AvatarInspector/RightFeetIk",
+        "AvatarInspector/LeftFeetIk", "AvatarInspector/RightFingers", "AvatarInspector/LeftFingers",
+        "AvatarInspector/RightArm", "AvatarInspector/LeftArm", "AvatarInspector/RightLeg", "AvatarInspector/LeftLeg",
+        "AvatarInspector/Head", "AvatarInspector/Torso", "AvatarInspector/MaskEditor_Root",
+        "AvatarInspector/BodyPartPicker", "AvatarInspector/BodySIlhouette", "boo Script Icon", "js Script Icon",
+        "EyeDropper.Large", "AboutWindow.MainHeader", "AgeiaLogo", "MonoLogo", "PlayButtonProfile Anim",
+        "StepButton Anim", "PauseButton Anim", "PlayButton Anim", "MoveTool On", "Icon Dropdown",
+        "AvatarInspector/DotSelection", "AvatarInspector/DotFrameDotted", "AvatarInspector/DotFrame",
+        "AvatarInspector/DotFill", "AvatarInspector/RightHandZoom", "AvatarInspector/LeftHandZoom",
+        "AvatarInspector/HeadZoom", "AvatarInspector/RightLeg", "AvatarInspector/LeftLeg",
+        "AvatarInspector/RightFingers", "AvatarInspector/RightArm", "AvatarInspector/LeftFingers",
+        "AvatarInspector/LeftArm", "AvatarInspector/Head", "AvatarInspector/Torso",
+        "AvatarInspector/RightHandZoomSilhouette", "AvatarInspector/LeftHandZoomSilhouette",
+        "AvatarInspector/HeadZoomSilhouette", "AvatarInspector/BodySilhouette", "lightMeter/redLight",
+        "lightMeter/orangeLight", "lightMeter/lightRim", "lightMeter/greenLight", "SceneviewAudio",
+        "SceneviewLighting", "TerrainInspector.TerrainToolSetHeight", "AS Badge New", "AS Badge Move",
+        "AS Badge Delete", "WelcomeScreen.UnityAnswersLogo", "WelcomeScreen.UnityForumLogo",
+        "WelcomeScreen.UnityBasicsLogo", "WelcomeScreen.VideoTutLogo", "WelcomeScreen.MainHeader", "Icon Dropdown",
+        "PrefabNormal Icon", "PrefabNormal Icon", "BuildSettings.BlackBerry.Small", "BuildSettings.Tizen.Small",
+        "BuildSettings.XBox360.Small", "BuildSettings.PS3.Small", "BuildSettings.SamsungTV.Small",
+        "BuildSettings.BlackBerry", "BuildSettings.Tizen", "BuildSettings.XBox360", "BuildSettings.PS3",
+        "BuildSettings.SamsungTV"
+    };
+
+    #endregion
+}
+#endif

--- a/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/FantasyUIHierarchyHelper.cs
+++ b/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/FantasyUIHierarchyHelper.cs
@@ -1,0 +1,349 @@
+﻿using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Fantasy
+{
+    public static class FantasyUIHierarchyHelper
+    {
+        private static readonly Dictionary<int, FantasyRef> IsReference = new();
+        private static readonly Dictionary<int, bool> FantasyRefs = new();
+        private static readonly Dictionary<int, FantasyRef> NotReference = new();
+        private static readonly HashSet<int> RemoveFlag = new();
+
+        private static Dictionary<string, string> NameComponentNameMap => FantasySettingsScriptableObject.Instance.FantasyUIAutoRefSettings;
+
+        private static GUIStyle Style => new(EditorStyles.label) { normal = { textColor = Color.green } };
+
+        [InitializeOnLoadMethod]
+        public static void DrawFantasyUIMark()
+        {
+            EditorApplication.hierarchyChanged += OnHierarchyChanged;
+            EditorApplication.hierarchyWindowItemOnGUI += OnHierarchyItemOnGUI;
+        }
+
+        private static void OnHierarchyChanged()
+        {
+            RefreshHierarchy();
+        }
+
+        public static void RefreshHierarchy()
+        {
+            if (EditorApplication.isPlayingOrWillChangePlaymode)
+            {
+                return;
+            }
+
+            FantasyRef[] fantasyUIs = null;
+            var prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+            if (prefabStage != null)
+            {
+                fantasyUIs = prefabStage.prefabContentsRoot.GetComponentsInChildren<FantasyRef>();
+            }
+
+            fantasyUIs ??= Object.FindObjectsByType<FantasyRef>(FindObjectsInactive.Include, FindObjectsSortMode.None);
+            IsReference.Clear();
+            NotReference.Clear();
+            foreach (var (key, _) in FantasyRefs)
+            {
+                RemoveFlag.Add(key);
+            }
+
+            foreach (var c in fantasyUIs)
+            {
+                var gameObjectInstanceID = c.gameObject.GetInstanceID();
+                FantasyRefs.TryAdd(gameObjectInstanceID, false);
+                RemoveFlag.Remove(gameObjectInstanceID);
+            }
+
+            foreach (var remove in RemoveFlag)
+            {
+                FantasyRefs.TryRemove(remove, out _);
+            }
+
+            foreach (var (key, value) in FantasyRefs)
+            {
+                if (!value)
+                    continue;
+                var gameObject = (GameObject)EditorUtility.InstanceIDToObject(key);
+                var c = gameObject.GetComponent<FantasyRef>();
+                c.list.ForEach(o =>
+                {
+                    var instanceID = (o.gameObject as Component)?.gameObject.GetInstanceID() ?? o.gameObject.GetInstanceID();
+                    IsReference.Add(instanceID, c);
+                });
+
+                var transformList = c.GetComponentsInChildren<Transform>(true);
+                foreach (var t in transformList)
+                {
+                    var instanceID = t.gameObject.GetInstanceID();
+                    if (t != c.transform && !IsReference.ContainsKey(instanceID))
+                    {
+                        NotReference.TryAdd(instanceID, c);
+                    }
+                }
+            }
+        }
+
+        private static void OnHierarchyItemOnGUI(int instanceID, Rect selectionRect)
+        {
+            if (EditorApplication.isPlayingOrWillChangePlaymode || !FantasySettingsScriptableObject.Instance.fantasyUIAutoRefFunction)
+            {
+                return;
+            }
+
+            DrawFantasyComponentTips(instanceID, selectionRect);
+
+            if (FantasyRefs.TryGetValue(instanceID, out var value))
+            {
+                var gameObject = (GameObject)EditorUtility.InstanceIDToObject(instanceID);
+                if (!gameObject)
+                    return;
+                var c = gameObject.GetComponent<FantasyRef>();
+                Rect r = new Rect(selectionRect.xMax - 60, selectionRect.y, 40, selectionRect.height);
+                if (c is FantasyUIRef)
+                {
+                    GUI.Label(r, "UI", Style);
+                }
+                else
+                {
+                    GUI.Label(r, c.isUI ? "SubUI" : "Ref", Style);
+                }
+
+                r.x -= 20;
+                r.width = 10;
+                FantasyRefs[instanceID] = GUI.Toggle(r, value, GUIContent.none);
+
+                if (FantasyRefs[instanceID] && FantasyRefs[instanceID] != value)
+                {
+                    int? target = null;
+                    foreach (var (key, b) in FantasyRefs)
+                    {
+                        if (b && key != instanceID) target = key;
+                    }
+
+                    if (target != null)
+                        FantasyRefs[(int)target] = false;
+                }
+
+                if (FantasyRefs[instanceID] != value)
+                    RefreshHierarchy();
+            }
+
+            if (IsReference.TryGetValue(instanceID, out var fantasyRef))
+            {
+                Rect r = new Rect(selectionRect.xMax - 60, selectionRect.y, 45, selectionRect.height);
+                GUI.backgroundColor = Color.red;
+                if (GUI.Button(r, "移除"))
+                {
+                    var gameObject = EditorUtility.InstanceIDToObject(instanceID);
+                    var list = gameObject.name.Split('_', 2);
+                    if (list.Length > 0)
+                    {
+                        var first = list[0];
+                        if (NameComponentNameMap.TryGetValue(first, out var componentNameStr))
+                        {
+                            var componentNameList = componentNameStr.Split(',');
+                            Component component = null;
+                            foreach (var componentName in componentNameList)
+                            {
+                                if (component)
+                                    break;
+                                component = (gameObject as GameObject)?.GetComponent(componentName);
+                            }
+
+                            gameObject = component ? component : gameObject;
+                        }
+                    }
+
+                    var targetInstanceId = gameObject.GetInstanceID();
+                    var idx = fantasyRef.list.FindIndex(data => data.gameObject.GetInstanceID() == targetInstanceId);
+                    if (idx >= 0 && idx < fantasyRef.list.Count)
+                    {
+                        fantasyRef.list.RemoveAt(idx);
+                        EditorUtility.SetDirty(fantasyRef);
+                    }
+
+                    RefreshHierarchy();
+                }
+
+                GUI.backgroundColor = Color.white;
+            }
+
+            if (NotReference.TryGetValue(instanceID, out fantasyRef))
+            {
+                Rect r = new Rect(selectionRect.xMax - 60, selectionRect.y, 45, selectionRect.height);
+                GUI.backgroundColor = Color.blue;
+                if (GUI.Button(r, "引用"))
+                {
+                    var gameObject = EditorUtility.InstanceIDToObject(instanceID);
+                    var list = gameObject.name.Split('_', 2);
+                    if (list.Length > 0)
+                    {
+                        var first = list[0];
+                        if (NameComponentNameMap.TryGetValue(first, out var componentNameStr))
+                        {
+                            componentNameStr = componentNameStr.Replace(" ", "");
+                            var componentNameList = componentNameStr.Split(',');
+                            Component component = null;
+                            foreach (var componentName in componentNameList)
+                            {
+                                if (component)
+                                    break;
+                                component = (gameObject as GameObject)?.GetComponent(componentName);
+                            }
+
+                            gameObject = component ? component : gameObject;
+                        }
+                    }
+
+                    fantasyRef.list.Add(new FantasyUIData()
+                    {
+                        key = gameObject.name,
+                        gameObject = gameObject,
+                    });
+                    EditorUtility.SetDirty(fantasyRef);
+                    RefreshHierarchy();
+                }
+
+                GUI.backgroundColor = Color.white;
+            }
+        }
+
+        private static void DrawFantasyComponentTips(int instanceID, Rect selectionRect)
+        {
+            var gameObject = (GameObject)EditorUtility.InstanceIDToObject(instanceID);
+            if (!gameObject)
+                return;
+
+
+            Rect r = new Rect(selectionRect.xMax - 10, selectionRect.y, 20, selectionRect.height);
+
+            // ReSharper disable once StringLiteralTypo
+            var warnIcon = EditorGUIUtility.IconContent("console.warnicon");
+            var scrollIcon = EditorGUIUtility.IconContent("d_ScrollRect Icon");
+
+            var fantasyScrollView = false;
+
+            if (gameObject.TryGetComponent<FantasyGridScrollView>(out var gridScrollView))
+            {
+                fantasyScrollView = true;
+                if (!gridScrollView.scrollRect || !gridScrollView.contentSizeFitter || !gridScrollView.gridLayoutGroup || !gridScrollView.itemTemplate)
+                {
+                    EditorGUI.LabelField(r, new GUIContent(warnIcon));
+                }
+                else
+                {
+                    EditorGUI.LabelField(r, new GUIContent(scrollIcon));
+                }
+            }
+
+            if (gameObject.TryGetComponent<FantasyVerticalScrollView>(out var verticalScrollView))
+            {
+                fantasyScrollView = true;
+                if (!verticalScrollView.scrollRect || !verticalScrollView.contentSizeFitter || !verticalScrollView.verticalLayoutGroup || !verticalScrollView.itemTemplate)
+                {
+                    EditorGUI.LabelField(r, new GUIContent(warnIcon));
+                }
+                else
+                {
+                    EditorGUI.LabelField(r, new GUIContent(scrollIcon));
+                }
+            }
+
+            if (gameObject.TryGetComponent<FantasyHorizontalScrollView>(out var horizontalScrollView))
+            {
+                fantasyScrollView = true;
+                if (!horizontalScrollView.scrollRect || !horizontalScrollView.contentSizeFitter || !horizontalScrollView.horizontalLayoutGroup || !horizontalScrollView.itemTemplate)
+                {
+                    EditorGUI.LabelField(r, new GUIContent(warnIcon));
+                }
+                else
+                {
+                    EditorGUI.LabelField(r, new GUIContent(scrollIcon));
+                }
+            }
+
+            var list = gameObject.name.Split('_', 2);
+            var canRecognize = list.Length > 0 && NameComponentNameMap.ContainsKey(list[0]);
+
+            if (!canRecognize) return;
+            var componentNames = NameComponentNameMap[list[0]];
+            if (string.IsNullOrEmpty(componentNames)) return;
+            var componentNameList = componentNames.Replace(" ", "").Split(",");
+            Component component = null;
+            foreach (var componentName in componentNameList)
+            {
+                component = gameObject.GetComponent(componentName);
+                if(component)
+                    break;
+            }
+
+            if (component == null) return;
+            switch (component)
+            {
+                case Button:
+                    EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_Button Icon")));
+                    break;
+                case Image:
+                    EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_Image Icon")));
+                    break;
+                case RawImage:
+                    EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_RawImage Icon")));
+                    break;
+                case Text:
+                    EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_Text Icon")));
+                    break;
+                case Toggle:
+                    EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_Toggle Icon")));
+                    break;
+                case ToggleGroup:
+                    EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_ToggleGroup Icon")));
+                    break;
+                case Slider:
+                    EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_Slider Icon")));
+                    break;
+                case Canvas:
+                    EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_Canvas Icon")));
+                    break;
+                case CanvasGroup:
+                    EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_CanvasGroup Icon")));
+                    break;
+                case Scrollbar:
+                    EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_Scrollbar Icon")));
+                    break;
+                case ScrollRect:
+                    if (!fantasyScrollView)
+                        EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_ScrollRect Icon")));
+                    break;
+                case InputField:
+                    EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_InputField Icon")));
+                    break;
+                case Dropdown:
+                    EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_Dropdown Icon")));
+                    break;
+                case RectTransform:
+                    EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_RectTransform Icon")));
+                    break;
+                case Transform:
+                    EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_Transform Icon")));
+                    break;
+            }
+
+            switch (componentNames)
+            {
+                case "TextMeshProUGUI":
+                    EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_Text Icon")));
+                    break;
+                case "TMP_InputField":
+                    EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_InputField Icon")));
+                    break;
+                case "TMP_Dropdown":
+                    EditorGUI.LabelField(r, new GUIContent(EditorGUIUtility.IconContent("d_Dropdown Icon")));
+                    break;
+            }
+        }
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/FantasyUIRefData.cs
+++ b/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/FantasyUIRefData.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace Fantasy
+{
+    [Serializable]
+    public class FantasyUIRefData
+    {
+        public string key;
+        public string value;
+    }
+
+    [CustomPropertyDrawer(typeof(FantasyUIRefData))]
+    public class FantasyUIRefDataDrawer : PropertyDrawer
+    {
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label) => 19f;
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            // base.OnGUI(position, property, label);
+            position.height = 18f;
+            using var propertyScope = new EditorGUI.PropertyScope(position, label, property);
+
+            // position = EditorGUI.PrefixLabel(position, GUIUtility.GetControlID(FocusType.Passive), label);
+
+            var keyRect = new Rect(position.x, position.y, position.width * 0.3f, position.height);
+            var valueRect = new Rect(position.x + position.width * 0.3f + 10f, position.y, position.width - position.width * 0.3f - 10f, position.height);
+
+            EditorGUI.PropertyField(keyRect, property.FindPropertyRelative("key"), GUIContent.none);
+            EditorGUI.PropertyField(valueRect, property.FindPropertyRelative("value"), GUIContent.none);
+        }
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UIEditor/FantasyGridScrollViewEditor.cs
+++ b/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UIEditor/FantasyGridScrollViewEditor.cs
@@ -1,0 +1,50 @@
+﻿using UnityEditor;
+
+namespace Fantasy
+{
+    [CustomEditor(typeof(FantasyGridScrollView))]
+    public class FantasyGridScrollViewEditor : Editor
+    {
+        private FantasyGridScrollView _target;
+
+        private SerializedProperty _scrollRect;
+        private SerializedProperty _gridLayoutGroup;
+        private SerializedProperty _contentSizeFitter;
+        private SerializedProperty _itemTemplate;
+
+        private void OnEnable()
+        {
+            _target = (FantasyGridScrollView)target;
+            _scrollRect = serializedObject.FindProperty("scrollRect");
+            _gridLayoutGroup = serializedObject.FindProperty("gridLayoutGroup");
+            _contentSizeFitter = serializedObject.FindProperty("contentSizeFitter");
+            _itemTemplate = serializedObject.FindProperty("itemTemplate");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+            using (new EditorGUI.DisabledGroupScope(EditorApplication.isPlayingOrWillChangePlaymode))
+            {
+                if (!_target.scrollRect)
+                    EditorGUILayout.HelpBox("Can't Be Null", MessageType.Error);
+                EditorGUILayout.PropertyField(_scrollRect);
+
+                if (!_target.gridLayoutGroup)
+                    EditorGUILayout.HelpBox("Can't Be Null", MessageType.Error);
+                EditorGUILayout.PropertyField(_gridLayoutGroup);
+
+                if (!_target.contentSizeFitter)
+                    EditorGUILayout.HelpBox("Can't Be Null", MessageType.Error);
+                EditorGUILayout.PropertyField(_contentSizeFitter);
+
+                EditorGUILayout.Space();
+                if (!_target.itemTemplate)
+                    EditorGUILayout.HelpBox("Can't Be Null", MessageType.Error);
+                EditorGUILayout.PropertyField(_itemTemplate);
+            }
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UIEditor/FantasyHorizontalScrollViewEditor.cs
+++ b/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UIEditor/FantasyHorizontalScrollViewEditor.cs
@@ -1,0 +1,50 @@
+﻿using UnityEditor;
+
+namespace Fantasy
+{
+    [CustomEditor(typeof(FantasyHorizontalScrollView))]
+    public class FantasyHorizontalScrollViewEditor : Editor
+    {
+        private FantasyHorizontalScrollView _target;
+
+        private SerializedProperty _scrollRect;
+        private SerializedProperty _horizontalLayoutGroup;
+        private SerializedProperty _contentSizeFitter;
+        private SerializedProperty _itemTemplate;
+
+        private void OnEnable()
+        {
+            _target = (FantasyHorizontalScrollView)target;
+            _scrollRect = serializedObject.FindProperty("scrollRect");
+            _horizontalLayoutGroup = serializedObject.FindProperty("horizontalLayoutGroup");
+            _contentSizeFitter = serializedObject.FindProperty("contentSizeFitter");
+            _itemTemplate = serializedObject.FindProperty("itemTemplate");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+            using (new EditorGUI.DisabledGroupScope(EditorApplication.isPlayingOrWillChangePlaymode))
+            {
+                if (!_target.scrollRect)
+                    EditorGUILayout.HelpBox("Can't Be Null", MessageType.Error);
+                EditorGUILayout.PropertyField(_scrollRect);
+
+                if (!_target.horizontalLayoutGroup)
+                    EditorGUILayout.HelpBox("Can't Be Null", MessageType.Error);
+                EditorGUILayout.PropertyField(_horizontalLayoutGroup);
+
+                if (!_target.contentSizeFitter)
+                    EditorGUILayout.HelpBox("Can't Be Null", MessageType.Error);
+                EditorGUILayout.PropertyField(_contentSizeFitter);
+
+                EditorGUILayout.Space();
+                if (!_target.itemTemplate)
+                    EditorGUILayout.HelpBox("Can't Be Null", MessageType.Error);
+                EditorGUILayout.PropertyField(_itemTemplate);
+            }
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UIEditor/FantasyRefEditor.cs
+++ b/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UIEditor/FantasyRefEditor.cs
@@ -1,0 +1,221 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Fantasy
+{
+    [CustomEditor(typeof(FantasyRef))]
+    public class FantasyRefEditor : Editor
+    {
+        private FantasyRef _fantasyRef;
+        private readonly HashSet<int> _remove = new();
+
+        private SerializedProperty _dataProperty;
+
+        private void OnEnable()
+        {
+            _fantasyRef = (FantasyRef)target;
+            _dataProperty = serializedObject.FindProperty("list");
+        }
+
+        public override void OnInspectorGUI()
+        {
+            EditorGUILayout.Space();
+
+            if (string.IsNullOrEmpty(_fantasyRef.componentName))
+            {
+                _fantasyRef.componentName = _fantasyRef.gameObject.name;
+            }
+
+            _fantasyRef.isUI = EditorGUILayout.Toggle(new GUIContent("Is UI", "生成时是否继承SubUI"), _fantasyRef.isUI);
+            _fantasyRef.moduleName = EditorGUILayout.TextField(new GUIContent("Module Name", "模块名，如果不为空，则生成时会生成对应名称的文件夹和命名空间"), _fantasyRef.moduleName);
+            EditorGUILayout.Space();
+            _fantasyRef.componentName = EditorGUILayout.TextField("Component Name", _fantasyRef.componentName);
+
+            EditorGUILayout.Space();
+
+            using (new GUILayout.HorizontalScope())
+            {
+                if (GUILayout.Button("Add"))
+                {
+                    AddReference(_dataProperty, Guid.NewGuid().GetHashCode().ToString(), null);
+                }
+
+                if (GUILayout.Button("Clear"))
+                {
+                    _dataProperty.ClearArray();
+                    EditorUtility.SetDirty(this);
+                    serializedObject.ApplyModifiedProperties();
+                    serializedObject.UpdateIfRequiredOrScript();
+                }
+
+                if (GUILayout.Button("Delete Empty"))
+                {
+                    for (var i = _dataProperty.arraySize - 1; i >= 0; i--)
+                    {
+                        var gameObjectProperty = _dataProperty.GetArrayElementAtIndex(i).FindPropertyRelative("gameObject");
+
+                        if (gameObjectProperty.objectReferenceValue != null)
+                        {
+                            continue;
+                        }
+
+                        _dataProperty.DeleteArrayElementAtIndex(i);
+                        EditorUtility.SetDirty(_fantasyRef);
+                        serializedObject.ApplyModifiedProperties();
+                        serializedObject.UpdateIfRequiredOrScript();
+                    }
+                }
+
+                if (GUILayout.Button("Sort"))
+                {
+                    _fantasyRef.list.Sort(new FantasyUIDataComparer());
+                    EditorUtility.SetDirty(this);
+                    serializedObject.ApplyModifiedProperties();
+                    serializedObject.UpdateIfRequiredOrScript();
+                }
+            }
+
+            if (GUILayout.Button(new GUIContent("Generate Code")))
+            {
+                GenerateCode();
+            }
+
+            for (var i = _fantasyRef.list.Count - 1; i >= 0; i--)
+            {
+                GUILayout.BeginHorizontal();
+                var property = _dataProperty.GetArrayElementAtIndex(i).FindPropertyRelative("key");
+                EditorGUILayout.TextField(property.stringValue, GUILayout.Width(150));
+                property = _dataProperty.GetArrayElementAtIndex(i).FindPropertyRelative("gameObject");
+                property.objectReferenceValue = EditorGUILayout.ObjectField(property.objectReferenceValue, typeof(Object), true);
+
+                if (GUILayout.Button("X"))
+                {
+                    _remove.Add(i);
+                }
+
+                GUILayout.EndHorizontal();
+            }
+
+            var eventType = Event.current.type;
+
+            if (eventType == EventType.DragUpdated || eventType == EventType.DragPerform)
+            {
+                DragAndDrop.visualMode = DragAndDropVisualMode.Copy;
+
+                if (eventType == EventType.DragPerform)
+                {
+                    DragAndDrop.AcceptDrag();
+
+                    foreach (var o in DragAndDrop.objectReferences)
+                    {
+                        AddReference(_dataProperty, o.name, o);
+                    }
+                }
+
+                Event.current.Use();
+            }
+
+            if (_remove.Count > 0)
+            {
+                foreach (var removeIndex in _remove)
+                {
+                    _dataProperty.DeleteArrayElementAtIndex(removeIndex);
+                }
+
+                _remove.Clear();
+            }
+
+            serializedObject.ApplyModifiedProperties();
+            serializedObject.UpdateIfRequiredOrScript();
+            FantasyUIHierarchyHelper.RefreshHierarchy();
+            EditorApplication.RepaintHierarchyWindow();
+        }
+
+        private void AddReference(SerializedProperty dataProperty, string key, Object obj)
+        {
+            var index = dataProperty.arraySize;
+            dataProperty.InsertArrayElementAtIndex(index);
+            var element = dataProperty.GetArrayElementAtIndex(index);
+            element.FindPropertyRelative("key").stringValue = key;
+            element.FindPropertyRelative("gameObject").objectReferenceValue = obj;
+        }
+
+        private void GenerateCode()
+        {
+            var generatePath = FantasySettingsScriptableObject.Instance.uiGenerateSavePath;
+
+            if (string.IsNullOrEmpty(_fantasyRef.componentName))
+            {
+                EditorUtility.DisplayDialog("Generate Code", $"componentName is null", "OK");
+                return;
+            }
+
+            bool isUI = _fantasyRef.isUI;
+            bool hasModule = !string.IsNullOrEmpty(_fantasyRef.moduleName);
+            generatePath = hasModule ? $"{generatePath}/Module/{_fantasyRef.moduleName}" : $"{generatePath}/SubUI";
+
+            if (!isUI && !hasModule)
+            {
+                EditorUtility.DisplayDialog("Generate Code", $"If FantasyRef is not a UI, then it should have a moduleName!", "OK");
+                return;
+            }
+
+            if (!Directory.Exists(generatePath))
+            {
+                Directory.CreateDirectory(generatePath);
+            }
+
+            var createStr = new List<string>();
+            var propertyStr = new List<string>();
+
+            for (var i = _fantasyRef.list.Count - 1; i >= 0; i--)
+            {
+                var keyProperty = _dataProperty.GetArrayElementAtIndex(i).FindPropertyRelative("key");
+                var gameObjectProperty = _dataProperty.GetArrayElementAtIndex(i).FindPropertyRelative("gameObject");
+                var refName = gameObjectProperty.objectReferenceValue.GetType().FullName;
+                var gameObjectName = Regex.Replace(keyProperty.stringValue, @"\s+", "");
+                propertyStr.Add($"\t\tpublic {refName} {gameObjectName};");
+                createStr.Add($"\t\t\t{gameObjectName} = referenceComponent.GetReference<{refName}>(\"{keyProperty.stringValue}\");");
+            }
+
+
+            var sb = new StringBuilder();
+
+            sb.AppendLine("using Fantasy;");
+            sb.AppendLine(hasModule ? $"\nnamespace Fantasy.{_fantasyRef.moduleName}\n{{" : "\nnamespace Fantasy\n{");
+            sb.AppendLine($"\tpublic partial class {_fantasyRef.componentName} : {(isUI ? "SubUI" : "Entity")}\n\t{{");
+
+            if (!isUI)
+                sb.AppendLine($"\t\tpublic GameObject GameObject;");
+
+            foreach (var property in propertyStr)
+            {
+                sb.AppendLine(property);
+            }
+
+            sb.AppendLine($"\n\t\tpublic{(isUI ? " override" : "")} void Initialize()\n\t\t{{");
+            sb.AppendLine("\t\t\tvar referenceComponent = GameObject.GetComponent<FantasyRef>();");
+
+            foreach (var str in createStr)
+            {
+                sb.AppendLine(str);
+            }
+
+            sb.AppendLine("\t\t}");
+            sb.AppendLine("\t}");
+            sb.AppendLine("}");
+
+            var combinePath = Path.Combine(generatePath, $"{_fantasyRef.componentName}.cs");
+            using var entityStreamWriter = new StreamWriter(combinePath);
+            entityStreamWriter.Write(sb.ToString());
+            AssetDatabase.Refresh();
+            Log.Debug($"代码生成位置:{combinePath}");
+        }
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UIEditor/FantasyUIRefEditor.cs
+++ b/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UIEditor/FantasyUIRefEditor.cs
@@ -1,0 +1,228 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Fantasy
+{
+    [CustomEditor(typeof(FantasyUIRef))]
+    public class FantasyUIRefEditor : Editor
+    {
+        private FantasyUIRef _fantasyUIRef;
+        private readonly HashSet<int> _remove = new();
+
+        private void OnEnable()
+        {
+            _fantasyUIRef = (FantasyUIRef)target;
+        }
+
+        public override void OnInspectorGUI()
+        {
+            var dataProperty = serializedObject.FindProperty("list");
+            EditorGUILayout.Space();
+
+            if (string.IsNullOrEmpty(_fantasyUIRef.componentName))
+            {
+                _fantasyUIRef.componentName = _fantasyUIRef.gameObject.name;
+            }
+
+            _fantasyUIRef.moduleName = EditorGUILayout.TextField(new GUIContent("Module Name", "模块名，如果不为空，则生成时会生成对应名称的文件夹和命名空间"), _fantasyUIRef.moduleName);
+
+            _fantasyUIRef.componentName = EditorGUILayout.TextField("Component Name", _fantasyUIRef.componentName);
+            _fantasyUIRef.assetName = EditorGUILayout.TextField("AssetName", _fantasyUIRef.assetName);
+            _fantasyUIRef.bundleName = EditorGUILayout.TextField("BundleName", _fantasyUIRef.bundleName);
+            _fantasyUIRef.uiLayer = (UILayer)EditorGUILayout.EnumPopup("UILayer", _fantasyUIRef.uiLayer);
+            EditorGUILayout.Space();
+
+            GUILayout.BeginHorizontal();
+
+            if (GUILayout.Button("Add"))
+            {
+                AddReference(dataProperty, Guid.NewGuid().GetHashCode().ToString(), null);
+            }
+
+            if (GUILayout.Button("Clear"))
+            {
+                dataProperty.ClearArray();
+                EditorUtility.SetDirty(this);
+                serializedObject.ApplyModifiedProperties();
+                serializedObject.UpdateIfRequiredOrScript();
+            }
+
+            if (GUILayout.Button("Delete Empty"))
+            {
+                for (var i = dataProperty.arraySize - 1; i >= 0; i--)
+                {
+                    var gameObjectProperty = dataProperty.GetArrayElementAtIndex(i).FindPropertyRelative("gameObject");
+
+                    if (gameObjectProperty.objectReferenceValue != null)
+                    {
+                        continue;
+                    }
+
+                    dataProperty.DeleteArrayElementAtIndex(i);
+                    EditorUtility.SetDirty(_fantasyUIRef);
+                    serializedObject.ApplyModifiedProperties();
+                    serializedObject.UpdateIfRequiredOrScript();
+                }
+            }
+
+            if (GUILayout.Button("Sort"))
+            {
+                _fantasyUIRef.list.Sort(new FantasyUIDataComparer());
+                EditorUtility.SetDirty(this);
+                serializedObject.ApplyModifiedProperties();
+                serializedObject.UpdateIfRequiredOrScript();
+            }
+
+            GUILayout.EndHorizontal();
+            GUILayout.BeginHorizontal();
+
+            if (GUILayout.Button(new GUIContent("Generate Code")))
+            {
+                Generate(dataProperty);
+            }
+
+            GUILayout.EndHorizontal();
+
+            for (var i = _fantasyUIRef.list.Count - 1; i >= 0; i--)
+            {
+                GUILayout.BeginHorizontal();
+                var property = dataProperty.GetArrayElementAtIndex(i).FindPropertyRelative("key");
+                EditorGUILayout.TextField(property.stringValue, GUILayout.Width(150));
+                property = dataProperty.GetArrayElementAtIndex(i).FindPropertyRelative("gameObject");
+                property.objectReferenceValue = EditorGUILayout.ObjectField(property.objectReferenceValue, typeof(Object), true);
+
+                if (GUILayout.Button("X"))
+                {
+                    _remove.Add(i);
+                }
+
+                GUILayout.EndHorizontal();
+            }
+
+            var eventType = Event.current.type;
+
+            if (eventType == EventType.DragUpdated || eventType == EventType.DragPerform)
+            {
+                DragAndDrop.visualMode = DragAndDropVisualMode.Copy;
+
+                if (eventType == EventType.DragPerform)
+                {
+                    DragAndDrop.AcceptDrag();
+
+                    foreach (var o in DragAndDrop.objectReferences)
+                    {
+                        AddReference(dataProperty, o.name, o);
+                    }
+                }
+
+                Event.current.Use();
+            }
+
+            if (_remove.Count > 0)
+            {
+                foreach (var removeIndex in _remove)
+                {
+                    dataProperty.DeleteArrayElementAtIndex(removeIndex);
+                }
+
+                _remove.Clear();
+            }
+
+            serializedObject.ApplyModifiedProperties();
+            serializedObject.UpdateIfRequiredOrScript();
+            FantasyUIHierarchyHelper.RefreshHierarchy();
+            EditorApplication.RepaintHierarchyWindow();
+        }
+
+        private void AddReference(SerializedProperty dataProperty, string key, Object obj)
+        {
+            var index = dataProperty.arraySize;
+            dataProperty.InsertArrayElementAtIndex(index);
+            var element = dataProperty.GetArrayElementAtIndex(index);
+            element.FindPropertyRelative("key").stringValue = key;
+            element.FindPropertyRelative("gameObject").objectReferenceValue = obj;
+        }
+
+        private void Generate(SerializedProperty dataProperty)
+        {
+            var generatePath = FantasySettingsScriptableObject.Instance.uiGenerateSavePath;
+
+            if (string.IsNullOrEmpty(_fantasyUIRef.assetName))
+            {
+                EditorUtility.DisplayDialog("Generate Code", $"assetName is null", "OK");
+                return;
+            }
+
+            if (string.IsNullOrEmpty(_fantasyUIRef.bundleName))
+            {
+                EditorUtility.DisplayDialog("Generate Code", $"bundleName is null", "OK");
+                return;
+            }
+
+            if (_fantasyUIRef.uiLayer == UILayer.None)
+            {
+                EditorUtility.DisplayDialog("Generate Code", $"UILayer is None", "OK");
+                return;
+            }
+
+            bool hasModule = !string.IsNullOrEmpty(_fantasyUIRef.moduleName);
+            generatePath = hasModule ? $"{generatePath}/Module/{_fantasyUIRef.moduleName}" : $"{generatePath}/Entity";
+
+            if (!Directory.Exists(generatePath))
+            {
+                Directory.CreateDirectory(generatePath);
+            }
+
+            var createStr = new List<string>();
+            var propertyStr = new List<string>();
+
+            for (var i = _fantasyUIRef.list.Count - 1; i >= 0; i--)
+            {
+                var keyProperty = dataProperty.GetArrayElementAtIndex(i).FindPropertyRelative("key");
+                var gameObjectProperty = dataProperty.GetArrayElementAtIndex(i).FindPropertyRelative("gameObject");
+                var refName = gameObjectProperty.objectReferenceValue.GetType().FullName;
+                var gameObjectName = Regex.Replace(keyProperty.stringValue, @"\s+", "");
+                propertyStr.Add($"\t\tpublic {refName} {gameObjectName};");
+                createStr.Add($"\t\t\t{gameObjectName} = referenceComponent.GetReference<{refName}>(\"{keyProperty.stringValue}\");");
+            }
+
+            var sb = new StringBuilder();
+
+            sb.AppendLine("using Fantasy;");
+            sb.AppendLine(hasModule ? $"\nnamespace Fantasy.{_fantasyUIRef.moduleName}\n{{" : "\nnamespace Fantasy\n{");
+            sb.AppendLine($"\tpublic partial class {_fantasyUIRef.componentName} : UI\n\t{{");
+            sb.AppendLine($"\t\tpublic override string AssetName {{ get; protected set; }} = \"{_fantasyUIRef.assetName}\";");
+            sb.AppendLine($"\t\tpublic override string BundleName {{ get; protected set; }} = \"{_fantasyUIRef.bundleName.ToLower()}\";");
+            sb.AppendLine($"\t\tpublic override UILayer Layer {{ get; protected set; }} = UILayer.{_fantasyUIRef.uiLayer.ToString()};\n");
+
+            foreach (var property in propertyStr)
+            {
+                sb.AppendLine(property);
+            }
+
+            sb.AppendLine("\n\t\tpublic override void Initialize()\n\t\t{");
+            sb.AppendLine("\t\t\tvar referenceComponent = GameObject.GetComponent<FantasyUIRef>();");
+
+            foreach (var str in createStr)
+            {
+                sb.AppendLine(str);
+            }
+
+            sb.AppendLine("\t\t}");
+            sb.AppendLine("\t}");
+            sb.AppendLine("}");
+
+            var combinePath = Path.Combine(generatePath, $"{_fantasyUIRef.componentName}.cs");
+            using var entityStreamWriter = new StreamWriter(combinePath);
+            entityStreamWriter.Write(sb.ToString());
+            AssetDatabase.Refresh();
+            Log.Debug($"代码生成位置:{combinePath}");
+        }
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UIEditor/FantasyVerticalScrollViewEditor.cs
+++ b/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UIEditor/FantasyVerticalScrollViewEditor.cs
@@ -1,0 +1,50 @@
+﻿using UnityEditor;
+
+namespace Fantasy
+{
+    [CustomEditor(typeof(FantasyVerticalScrollView))]
+    public class FantasyVerticalScrollViewEditor :Editor
+    {
+        private FantasyVerticalScrollView _target;
+
+        private SerializedProperty _scrollRect;
+        private SerializedProperty _verticalLayoutGroup;
+        private SerializedProperty _contentSizeFitter;
+        private SerializedProperty _itemTemplate;
+
+        private void OnEnable()
+        {
+            _target = (FantasyVerticalScrollView)target;
+            _scrollRect = serializedObject.FindProperty("scrollRect");
+            _verticalLayoutGroup = serializedObject.FindProperty("verticalLayoutGroup");
+            _contentSizeFitter = serializedObject.FindProperty("contentSizeFitter");
+            _itemTemplate = serializedObject.FindProperty("itemTemplate");
+        }
+        
+        public override void OnInspectorGUI()
+        {
+            serializedObject.Update();
+            using (new EditorGUI.DisabledGroupScope(EditorApplication.isPlayingOrWillChangePlaymode))
+            {
+                if (!_target.scrollRect)
+                    EditorGUILayout.HelpBox("Can't Be Null", MessageType.Error);
+                EditorGUILayout.PropertyField(_scrollRect);
+
+                if (!_target.verticalLayoutGroup)
+                    EditorGUILayout.HelpBox("Can't Be Null", MessageType.Error);
+                EditorGUILayout.PropertyField(_verticalLayoutGroup);
+
+                if (!_target.contentSizeFitter)
+                    EditorGUILayout.HelpBox("Can't Be Null", MessageType.Error);
+                EditorGUILayout.PropertyField(_contentSizeFitter);
+
+                EditorGUILayout.Space();
+                if (!_target.itemTemplate)
+                    EditorGUILayout.HelpBox("Can't Be Null", MessageType.Error);
+                EditorGUILayout.PropertyField(_itemTemplate);
+            }
+
+            serializedObject.ApplyModifiedProperties();
+        }
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UIEditor/GridLayoutGroupEditor.cs
+++ b/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UIEditor/GridLayoutGroupEditor.cs
@@ -1,0 +1,30 @@
+﻿using UnityEditor;
+using UnityEngine.UI;
+
+namespace Fantasy
+{
+    [CustomEditor(typeof(GridLayoutGroup), true)]
+    [CanEditMultipleObjects]
+    public class GridLayoutGroupEditor : UnityEditor.UI.GridLayoutGroupEditor
+    {
+        private GridLayoutGroup _target;
+        private int _targetInstanceId;
+
+        protected override void OnEnable()
+        {
+            _target = (GridLayoutGroup)target;
+            _targetInstanceId = _target.GetInstanceID();
+            base.OnEnable();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            EditorGUI.BeginChangeCheck();
+            base.OnInspectorGUI();
+            if (EditorGUI.EndChangeCheck())
+            {
+                FantasyEditorEventHelper.Trigger(_targetInstanceId);
+            }
+        }
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UIEditor/HorizontalOrVerticalLayoutGroupEditor.cs
+++ b/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UIEditor/HorizontalOrVerticalLayoutGroupEditor.cs
@@ -1,0 +1,30 @@
+﻿using UnityEditor;
+using UnityEngine.UI;
+
+namespace Fantasy
+{
+    [CustomEditor(typeof(HorizontalOrVerticalLayoutGroup), true)]
+    [CanEditMultipleObjects]
+    public class HorizontalOrVerticalLayoutGroupEditor : UnityEditor.UI.HorizontalOrVerticalLayoutGroupEditor
+    {
+        private HorizontalOrVerticalLayoutGroup _target;
+        private int _targetInstanceId;
+
+        protected override void OnEnable()
+        {
+            _target = (HorizontalOrVerticalLayoutGroup)target;
+            _targetInstanceId = _target.GetInstanceID();
+            base.OnEnable();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            EditorGUI.BeginChangeCheck();
+            base.OnInspectorGUI();
+            if (EditorGUI.EndChangeCheck())
+            {
+                FantasyEditorEventHelper.Trigger(_targetInstanceId);
+            }
+        }
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UITemplate/FantasyUITemplateMenuItems.cs
+++ b/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UITemplate/FantasyUITemplateMenuItems.cs
@@ -1,0 +1,247 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace Fantasy
+{
+    public static class FantasyUITemplateMenuItems
+    {
+        [MenuItem("GameObject/FantasyUI/Vertical ScrollView", false, 0)]
+        private static void AddVerticalScrollView(MenuCommand menuCommand)
+        {
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>("Packages/com.fantasy.unity/Editor/FantasyUI/UITemplate/VerticalCircleScrollView.prefab");
+            var go = Object.Instantiate(prefab);
+            go.name = "CircleVerticalScrollView";
+            PlaceUIElementRoot(go, menuCommand);
+        }
+
+        [MenuItem("GameObject/FantasyUI/Horizontal ScrollView", false, 1)]
+        private static void AddHorizontalScrollView(MenuCommand menuCommand)
+        {
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>("Packages/com.fantasy.unity/Editor/FantasyUI/UITemplate/HorizontalCircleScrollView.prefab");
+            var go = Object.Instantiate(prefab);
+            go.name = "CircleHorizontalScrollView";
+            PlaceUIElementRoot(go, menuCommand);
+        }
+
+        [MenuItem("GameObject/FantasyUI/Grid ScrollView", false, 2)]
+        private static void AddGridCircleScrollView(MenuCommand menuCommand)
+        {
+            GameObject prefab = AssetDatabase.LoadAssetAtPath<GameObject>("Packages/com.fantasy.unity/Editor/FantasyUI/UITemplate/GridCircleScrollView.prefab");
+            var go = Object.Instantiate(prefab);
+            go.name = "GridCircleScrollView";
+            PlaceUIElementRoot(go, menuCommand);
+        }
+        
+        #region UGUI源码
+
+        private static void PlaceUIElementRoot(GameObject element, MenuCommand menuCommand)
+        {
+            GameObject parent = menuCommand.context as GameObject;
+            bool explicitParentChoice = true;
+            if (parent == null)
+            {
+                parent = GetOrCreateCanvasGameObject();
+                explicitParentChoice = false;
+
+                // If in Prefab Mode, Canvas has to be part of Prefab contents,
+                // otherwise use Prefab root instead.
+                PrefabStage prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+                if (prefabStage != null && !prefabStage.IsPartOfPrefabContents(parent))
+                    parent = prefabStage.prefabContentsRoot;
+            }
+
+            if (parent.GetComponentsInParent<Canvas>(true).Length == 0)
+            {
+                // Create canvas under context GameObject,
+                // and make that be the parent which UI element is added under.
+                GameObject canvas = CreateNewUI();
+                Undo.SetTransformParent(canvas.transform, parent.transform, "");
+                parent = canvas;
+            }
+
+            GameObjectUtility.EnsureUniqueNameForSibling(element);
+
+            SetParentAndAlign(element, parent);
+            if (!explicitParentChoice) // not a context click, so center in sceneView
+                SetPositionVisibleInSceneView(parent.GetComponent<RectTransform>(), element.GetComponent<RectTransform>());
+
+            // This call ensure any change made to created Objects after they where registered will be part of the Undo.
+            Undo.RegisterFullObjectHierarchyUndo(parent == null ? element : parent, "");
+
+            // We have to fix up the undo name since the name of the object was only known after reParenting it.
+            Undo.SetCurrentGroupName("Create " + element.name);
+
+            Selection.activeGameObject = element;
+        }
+
+        // Helper function that returns a Canvas GameObject; preferably a parent of the selection, or other existing Canvas.
+        private static GameObject GetOrCreateCanvasGameObject()
+        {
+            GameObject selectedGo = Selection.activeGameObject;
+
+            // Try to find a gameObject that is the selected GO or one if its parents.
+            Canvas canvas = (selectedGo != null) ? selectedGo.GetComponentInParent<Canvas>() : null;
+            if (IsValidCanvas(canvas))
+                return canvas!.gameObject;
+
+            // No canvas in selection or its parents? Then use any valid canvas.
+            // We have to find all loaded Canvases, not just the ones in main scenes.
+            Canvas[] canvasArray = StageUtility.GetCurrentStageHandle().FindComponentsOfType<Canvas>();
+            foreach (var t in canvasArray)
+                if (IsValidCanvas(t))
+                    return t.gameObject;
+
+            // No canvas in the scene at all? Then create a new one.
+            return CreateNewUI();
+        }
+
+        static bool IsValidCanvas(Canvas canvas)
+        {
+            if (canvas == null || !canvas.gameObject.activeInHierarchy)
+                return false;
+
+            // It's important that the non-editable canvas from a prefab scene won't be rejected,
+            // but canvases not visible in the Hierarchy at all do. Don't check for HideAndDontSave.
+            if (EditorUtility.IsPersistent(canvas) || (canvas.hideFlags & HideFlags.HideInHierarchy) != 0)
+                return false;
+
+            return StageUtility.GetStageHandle(canvas.gameObject) == StageUtility.GetCurrentStageHandle();
+        }
+
+        public static GameObject CreateNewUI()
+        {
+            // Root for the UI
+            var root = ObjectFactory.CreateGameObject("Canvas", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+            root.layer = LayerMask.NameToLayer("UI");
+            Canvas canvas = root.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+
+            // Works for all stages.
+            StageUtility.PlaceGameObjectInCurrentStage(root);
+            bool customScene = false;
+            PrefabStage prefabStage = PrefabStageUtility.GetCurrentPrefabStage();
+            if (prefabStage != null)
+            {
+                Undo.SetTransformParent(root.transform, prefabStage.prefabContentsRoot.transform, "");
+                customScene = true;
+            }
+
+            Undo.SetCurrentGroupName("Create " + root.name);
+
+            // If there is no event system add one...
+            // No need to place event system in custom scene as these are temporary anyway.
+            // It can be argued for or against placing it in the user scenes,
+            // but let's not modify scene user is not currently looking at.
+            if (!customScene)
+                CreateEventSystem(false);
+            return root;
+        }
+
+        private static void CreateEventSystem(bool select, GameObject parent = null)
+        {
+            StageHandle stage = parent == null ? StageUtility.GetCurrentStageHandle() : StageUtility.GetStageHandle(parent);
+            // ReSharper disable once IdentifierTypo
+            var esys = stage.FindComponentOfType<UnityEngine.EventSystems.EventSystem>();
+            if (esys == null)
+            {
+                var eventSystem = ObjectFactory.CreateGameObject("EventSystem");
+                if (parent == null)
+                    StageUtility.PlaceGameObjectInCurrentStage(eventSystem);
+                else
+                    SetParentAndAlign(eventSystem, parent);
+                esys = ObjectFactory.AddComponent<UnityEngine.EventSystems.EventSystem>(eventSystem);
+                ObjectFactory.AddComponent<StandaloneInputModule>(eventSystem);
+
+                Undo.RegisterCreatedObjectUndo(eventSystem, "Create " + eventSystem.name);
+            }
+
+            if (select && esys != null)
+            {
+                Selection.activeGameObject = esys.gameObject;
+            }
+        }
+
+        private static void SetParentAndAlign(GameObject child, GameObject parent)
+        {
+            if (parent == null)
+                return;
+
+            Undo.SetTransformParent(child.transform, parent.transform, "");
+
+            RectTransform rectTransform = child.transform as RectTransform;
+            if (rectTransform)
+            {
+                rectTransform.anchoredPosition = Vector2.zero;
+                Vector3 localPosition = rectTransform.localPosition;
+                localPosition.z = 0;
+                rectTransform.localPosition = localPosition;
+            }
+            else
+            {
+                child.transform.localPosition = Vector3.zero;
+            }
+
+            child.transform.localRotation = Quaternion.identity;
+            child.transform.localScale = Vector3.one;
+
+            SetLayerRecursively(child, parent.layer);
+        }
+
+        private static void SetLayerRecursively(GameObject go, int layer)
+        {
+            go.layer = layer;
+            Transform t = go.transform;
+            for (int i = 0; i < t.childCount; i++)
+                SetLayerRecursively(t.GetChild(i).gameObject, layer);
+        }
+
+        [SuppressMessage("ReSharper", "PossibleLossOfFraction")]
+        [SuppressMessage("ReSharper", "Unity.InefficientPropertyAccess")]
+        private static void SetPositionVisibleInSceneView(RectTransform canvasRTransform, RectTransform itemTransform)
+        {
+            SceneView sceneView = SceneView.lastActiveSceneView;
+
+            // Couldn't find a SceneView. Don't set position.
+            if (sceneView == null || sceneView.camera == null)
+                return;
+
+            // Create world space Plane from canvas position.
+            Camera camera = sceneView.camera;
+            Vector3 position = Vector3.zero;
+            if (RectTransformUtility.ScreenPointToLocalPointInRectangle(canvasRTransform, new Vector2(camera.pixelWidth / 2, camera.pixelHeight / 2), camera, out var localPlanePosition))
+            {
+                // Adjust for canvas pivot
+                localPlanePosition.x = localPlanePosition.x + canvasRTransform.sizeDelta.x * canvasRTransform.pivot.x;
+                localPlanePosition.y = localPlanePosition.y + canvasRTransform.sizeDelta.y * canvasRTransform.pivot.y;
+
+                localPlanePosition.x = Mathf.Clamp(localPlanePosition.x, 0, canvasRTransform.sizeDelta.x);
+                localPlanePosition.y = Mathf.Clamp(localPlanePosition.y, 0, canvasRTransform.sizeDelta.y);
+
+                // Adjust for anchoring
+                position.x = localPlanePosition.x - canvasRTransform.sizeDelta.x * itemTransform.anchorMin.x;
+                position.y = localPlanePosition.y - canvasRTransform.sizeDelta.y * itemTransform.anchorMin.y;
+
+                Vector3 minLocalPosition;
+                minLocalPosition.x = canvasRTransform.sizeDelta.x * (0 - canvasRTransform.pivot.x) + itemTransform.sizeDelta.x * itemTransform.pivot.x;
+                minLocalPosition.y = canvasRTransform.sizeDelta.y * (0 - canvasRTransform.pivot.y) + itemTransform.sizeDelta.y * itemTransform.pivot.y;
+
+                Vector3 maxLocalPosition;
+                maxLocalPosition.x = canvasRTransform.sizeDelta.x * (1 - canvasRTransform.pivot.x) - itemTransform.sizeDelta.x * itemTransform.pivot.x;
+                maxLocalPosition.y = canvasRTransform.sizeDelta.y * (1 - canvasRTransform.pivot.y) - itemTransform.sizeDelta.y * itemTransform.pivot.y;
+
+                position.x = Mathf.Clamp(position.x, minLocalPosition.x, maxLocalPosition.x);
+                position.y = Mathf.Clamp(position.y, minLocalPosition.y, maxLocalPosition.y);
+            }
+
+            itemTransform.anchoredPosition = position;
+            itemTransform.localRotation = Quaternion.identity;
+            itemTransform.localScale = Vector3.one;
+        }
+
+        #endregion
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UITemplate/GridCircleScrollView.prefab
+++ b/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UITemplate/GridCircleScrollView.prefab
@@ -1,0 +1,898 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1340407002703633189
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1199526599199350692}
+  - component: {fileID: 7572931781887761120}
+  - component: {fileID: 2571141010106509582}
+  - component: {fileID: 7227731339910701487}
+  - component: {fileID: 5806813250447637735}
+  m_Layer: 5
+  m_Name: Content
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1199526599199350692
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1340407002703633189}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7981396420924855738}
+  m_Father: {fileID: 7840550626891041059}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: -0.000043012886}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &7572931781887761120
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1340407002703633189}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 2
+--- !u!114 &2571141010106509582
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1340407002703633189}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a8695521f0d02e499659fee002a26c2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 10
+    m_Right: 10
+    m_Top: 10
+    m_Bottom: 10
+  m_ChildAlignment: 2
+  m_StartCorner: 0
+  m_StartAxis: 0
+  m_CellSize: {x: 50, y: 50}
+  m_Spacing: {x: 10, y: 10}
+  m_Constraint: 0
+  m_ConstraintCount: 6
+--- !u!222 &7227731339910701487
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1340407002703633189}
+  m_CullTransparentMesh: 1
+--- !u!114 &5806813250447637735
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1340407002703633189}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.2830189, g: 0.21982911, b: 0.21982911, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4017546211246723745
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7840550626891041059}
+  - component: {fileID: 3582066996531446969}
+  - component: {fileID: 8964538162899904201}
+  - component: {fileID: 492186972806367390}
+  m_Layer: 5
+  m_Name: Viewport
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7840550626891041059
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4017546211246723745}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1199526599199350692}
+  m_Father: {fileID: 6269327387794731890}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &3582066996531446969
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4017546211246723745}
+  m_CullTransparentMesh: 1
+--- !u!114 &8964538162899904201
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4017546211246723745}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10917, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &492186972806367390
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4017546211246723745}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 0
+--- !u!1 &4167715223557792998
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7981396420924855738}
+  - component: {fileID: 8971567020082602633}
+  - component: {fileID: 3205860388542013497}
+  - component: {fileID: 5600511956017534631}
+  m_Layer: 5
+  m_Name: ItemTemplate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7981396420924855738
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4167715223557792998}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1199526599199350692}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8971567020082602633
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4167715223557792998}
+  m_CullTransparentMesh: 1
+--- !u!114 &3205860388542013497
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4167715223557792998}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5600511956017534631
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4167715223557792998}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fdbfc55e3ee5444b942bee9053875a53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  componentName: Image
+  list: []
+--- !u!1 &5249812837032534023
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1086235940892689776}
+  m_Layer: 5
+  m_Name: Sliding Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1086235940892689776
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5249812837032534023}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5330160353208816787}
+  m_Father: {fileID: 4368955584767561177}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &5761286664994949591
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5581376189738862215}
+  - component: {fileID: 6175169498089805344}
+  - component: {fileID: 876203589066328313}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5581376189738862215
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5761286664994949591}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8820707447900254554}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: NaN, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6175169498089805344
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5761286664994949591}
+  m_CullTransparentMesh: 1
+--- !u!114 &876203589066328313
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5761286664994949591}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6289010644781007659
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5330160353208816787}
+  - component: {fileID: 4586646558634020282}
+  - component: {fileID: 8653666510693005578}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5330160353208816787
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6289010644781007659}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1086235940892689776}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: NaN}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4586646558634020282
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6289010644781007659}
+  m_CullTransparentMesh: 1
+--- !u!114 &8653666510693005578
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6289010644781007659}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6516951222713152599
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8820707447900254554}
+  m_Layer: 5
+  m_Name: Sliding Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8820707447900254554
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6516951222713152599}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5581376189738862215}
+  m_Father: {fileID: 7244156203071277634}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &6566693086568907043
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7244156203071277634}
+  - component: {fileID: 3049786202603119892}
+  - component: {fileID: 2947922941230939278}
+  - component: {fileID: 7748781704243468487}
+  m_Layer: 5
+  m_Name: Scrollbar Horizontal
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7244156203071277634
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6566693086568907043}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8820707447900254554}
+  m_Father: {fileID: 6269327387794731890}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 20}
+  m_Pivot: {x: 0, y: 0}
+--- !u!222 &3049786202603119892
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6566693086568907043}
+  m_CullTransparentMesh: 1
+--- !u!114 &2947922941230939278
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6566693086568907043}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7748781704243468487
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6566693086568907043}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a4db7a114972834c8e4117be1d82ba3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 876203589066328313}
+  m_HandleRect: {fileID: 5581376189738862215}
+  m_Direction: 0
+  m_Value: 0
+  m_Size: 1
+  m_NumberOfSteps: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &6671218311691663697
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4368955584767561177}
+  - component: {fileID: 2199214131867640809}
+  - component: {fileID: 7765036196810609315}
+  - component: {fileID: 372752591089537510}
+  m_Layer: 5
+  m_Name: Scrollbar Vertical
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4368955584767561177
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6671218311691663697}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1086235940892689776}
+  m_Father: {fileID: 6269327387794731890}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 1, y: 1}
+--- !u!222 &2199214131867640809
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6671218311691663697}
+  m_CullTransparentMesh: 1
+--- !u!114 &7765036196810609315
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6671218311691663697}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &372752591089537510
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6671218311691663697}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a4db7a114972834c8e4117be1d82ba3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 8653666510693005578}
+  m_HandleRect: {fileID: 5330160353208816787}
+  m_Direction: 2
+  m_Value: 1
+  m_Size: 1
+  m_NumberOfSteps: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &7921998572750156789
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6269327387794731890}
+  - component: {fileID: 1406784221416295509}
+  - component: {fileID: 2304687473675223013}
+  - component: {fileID: 6213612639203383152}
+  - component: {fileID: 8325818385842273590}
+  m_Layer: 5
+  m_Name: GridCircleScrollView
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6269327387794731890
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7921998572750156789}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7840550626891041059}
+  - {fileID: 7244156203071277634}
+  - {fileID: 4368955584767561177}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1406784221416295509
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7921998572750156789}
+  m_CullTransparentMesh: 1
+--- !u!114 &2304687473675223013
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7921998572750156789}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6213612639203383152
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7921998572750156789}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1aa08ab6e0800fa44ae55d278d1423e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Content: {fileID: 1199526599199350692}
+  m_Horizontal: 1
+  m_Vertical: 1
+  m_MovementType: 1
+  m_Elasticity: 0.1
+  m_Inertia: 1
+  m_DecelerationRate: 0.135
+  m_ScrollSensitivity: 1
+  m_Viewport: {fileID: 7840550626891041059}
+  m_HorizontalScrollbar: {fileID: 7748781704243468487}
+  m_VerticalScrollbar: {fileID: 372752591089537510}
+  m_HorizontalScrollbarVisibility: 2
+  m_VerticalScrollbarVisibility: 2
+  m_HorizontalScrollbarSpacing: -3
+  m_VerticalScrollbarSpacing: -3
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &8325818385842273590
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7921998572750156789}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36a4ea996986482b93f52585a76f6137, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scrollRect: {fileID: 6213612639203383152}
+  itemTemplate: {fileID: 5600511956017534631}
+  gridLayoutGroup: {fileID: 2571141010106509582}
+  contentSizeFitter: {fileID: 7572931781887761120}

--- a/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UITemplate/HorizontalCircleScrollView.prefab
+++ b/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UITemplate/HorizontalCircleScrollView.prefab
@@ -1,0 +1,622 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1040528369200827847
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2042699798639641162}
+  - component: {fileID: 7155811534328473014}
+  - component: {fileID: 3622008986782965291}
+  m_Layer: 5
+  m_Name: Content
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2042699798639641162
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1040528369200827847}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4490355538653854389}
+  m_Father: {fileID: 7052360263643424686}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &7155811534328473014
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1040528369200827847}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 2
+  m_VerticalFit: 0
+--- !u!114 &3622008986782965291
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1040528369200827847}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 10
+    m_Right: 10
+    m_Top: 10
+    m_Bottom: 10
+  m_ChildAlignment: 0
+  m_Spacing: 10
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!1 &1689951984110989654
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8893093593199265750}
+  - component: {fileID: 7519042439805841758}
+  - component: {fileID: 4908852383984787230}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8893093593199265750
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689951984110989654}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 759060438216322543}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7519042439805841758
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689951984110989654}
+  m_CullTransparentMesh: 1
+--- !u!114 &4908852383984787230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1689951984110989654}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2179812799321158866
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3811525683840111620}
+  - component: {fileID: 6434752506584936208}
+  - component: {fileID: 4820066533937651157}
+  - component: {fileID: 3621817228649732835}
+  - component: {fileID: 7713945860079627490}
+  m_Layer: 5
+  m_Name: HorizontalCircleScrollView
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3811525683840111620
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2179812799321158866}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7052360263643424686}
+  - {fileID: 7583410343540055157}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 142.86133}
+  m_SizeDelta: {x: 200, y: 209.1373}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6434752506584936208
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2179812799321158866}
+  m_CullTransparentMesh: 1
+--- !u!114 &4820066533937651157
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2179812799321158866}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3621817228649732835
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2179812799321158866}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1aa08ab6e0800fa44ae55d278d1423e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Content: {fileID: 2042699798639641162}
+  m_Horizontal: 1
+  m_Vertical: 0
+  m_MovementType: 1
+  m_Elasticity: 0.1
+  m_Inertia: 1
+  m_DecelerationRate: 0.135
+  m_ScrollSensitivity: 1
+  m_Viewport: {fileID: 7052360263643424686}
+  m_HorizontalScrollbar: {fileID: 837070518052818642}
+  m_VerticalScrollbar: {fileID: 0}
+  m_HorizontalScrollbarVisibility: 2
+  m_VerticalScrollbarVisibility: 2
+  m_HorizontalScrollbarSpacing: -3
+  m_VerticalScrollbarSpacing: -3
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &7713945860079627490
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2179812799321158866}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 77cdee8da527428a9a2485cdbb7d6151, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scrollRect: {fileID: 3621817228649732835}
+  itemTemplate: {fileID: 4141392910393231413}
+  horizontalLayoutGroup: {fileID: 3622008986782965291}
+  contentSizeFitter: {fileID: 7155811534328473014}
+--- !u!1 &2230304659356379898
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7052360263643424686}
+  - component: {fileID: 8460437070557820125}
+  - component: {fileID: 2504426553968867279}
+  - component: {fileID: 3610717115806028116}
+  m_Layer: 5
+  m_Name: Viewport
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7052360263643424686
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2230304659356379898}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2042699798639641162}
+  m_Father: {fileID: 3811525683840111620}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &8460437070557820125
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2230304659356379898}
+  m_CullTransparentMesh: 1
+--- !u!114 &2504426553968867279
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2230304659356379898}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10917, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3610717115806028116
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2230304659356379898}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 0
+--- !u!1 &2433148507370107190
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4490355538653854389}
+  - component: {fileID: 5715461152156415487}
+  - component: {fileID: 7831277845891590279}
+  - component: {fileID: 4141392910393231413}
+  m_Layer: 5
+  m_Name: ItemTemplate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4490355538653854389
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2433148507370107190}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2042699798639641162}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 60, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5715461152156415487
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2433148507370107190}
+  m_CullTransparentMesh: 1
+--- !u!114 &7831277845891590279
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2433148507370107190}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.44025147, g: 0.43886703, b: 0.43886703, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &4141392910393231413
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2433148507370107190}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fdbfc55e3ee5444b942bee9053875a53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  componentName: ItemTemplate
+  list: []
+--- !u!1 &2439269795087620087
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 759060438216322543}
+  m_Layer: 5
+  m_Name: Sliding Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &759060438216322543
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2439269795087620087}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8893093593199265750}
+  m_Father: {fileID: 7583410343540055157}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &7904472691896474665
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7583410343540055157}
+  - component: {fileID: 2294397636900447033}
+  - component: {fileID: 2069305309731231776}
+  - component: {fileID: 837070518052818642}
+  m_Layer: 5
+  m_Name: Scrollbar Horizontal
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7583410343540055157
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7904472691896474665}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 759060438216322543}
+  m_Father: {fileID: 3811525683840111620}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 20}
+  m_Pivot: {x: 0, y: 0}
+--- !u!222 &2294397636900447033
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7904472691896474665}
+  m_CullTransparentMesh: 1
+--- !u!114 &2069305309731231776
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7904472691896474665}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &837070518052818642
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7904472691896474665}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a4db7a114972834c8e4117be1d82ba3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 4908852383984787230}
+  m_HandleRect: {fileID: 8893093593199265750}
+  m_Direction: 0
+  m_Value: 0
+  m_Size: 1
+  m_NumberOfSteps: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UITemplate/VerticalCircleScrollView.prefab
+++ b/Packages.Unity/Fantasy.Unity/Editor/FantasyUI/UITemplate/VerticalCircleScrollView.prefab
@@ -1,0 +1,622 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &206204319954528758
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6961385225631420064}
+  - component: {fileID: 2918002311821417092}
+  - component: {fileID: 5706243645429808596}
+  - component: {fileID: 1229892227468372650}
+  - component: {fileID: 2571608432143452313}
+  m_Layer: 5
+  m_Name: VerticalCircleScrollView
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6961385225631420064
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 206204319954528758}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1065819148498040535}
+  - {fileID: 8763837148463987636}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 147.43}
+  m_SizeDelta: {x: 200, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2918002311821417092
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 206204319954528758}
+  m_CullTransparentMesh: 1
+--- !u!114 &5706243645429808596
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 206204319954528758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.392}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1229892227468372650
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 206204319954528758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1aa08ab6e0800fa44ae55d278d1423e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Content: {fileID: 5126671053675922475}
+  m_Horizontal: 0
+  m_Vertical: 1
+  m_MovementType: 1
+  m_Elasticity: 0.1
+  m_Inertia: 1
+  m_DecelerationRate: 0.135
+  m_ScrollSensitivity: 1
+  m_Viewport: {fileID: 1065819148498040535}
+  m_HorizontalScrollbar: {fileID: 0}
+  m_VerticalScrollbar: {fileID: 221180480123000713}
+  m_HorizontalScrollbarVisibility: 2
+  m_VerticalScrollbarVisibility: 2
+  m_HorizontalScrollbarSpacing: -3
+  m_VerticalScrollbarSpacing: -3
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &2571608432143452313
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 206204319954528758}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1284bfbf12614600967e0ef19b155918, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scrollRect: {fileID: 1229892227468372650}
+  itemTemplate: {fileID: 3017615792159966128}
+  verticalLayoutGroup: {fileID: 3740809630349810688}
+  contentSizeFitter: {fileID: 1059404408605194623}
+--- !u!1 &1543230866240951640
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 506726505260495279}
+  - component: {fileID: 2358590013323508548}
+  - component: {fileID: 3399012494235706713}
+  - component: {fileID: 3017615792159966128}
+  m_Layer: 5
+  m_Name: ItemTemplate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &506726505260495279
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1543230866240951640}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5126671053675922475}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2358590013323508548
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1543230866240951640}
+  m_CullTransparentMesh: 1
+--- !u!114 &3399012494235706713
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1543230866240951640}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.44025147, g: 0.43886703, b: 0.43886703, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &3017615792159966128
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1543230866240951640}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fdbfc55e3ee5444b942bee9053875a53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  componentName: ItemTemplate
+  list: []
+--- !u!1 &3639245684526317525
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3017195406389831313}
+  m_Layer: 5
+  m_Name: Sliding Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3017195406389831313
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3639245684526317525}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3746545968163091893}
+  m_Father: {fileID: 8763837148463987636}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &4074755975807166688
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1065819148498040535}
+  - component: {fileID: 457192596528073725}
+  - component: {fileID: 6883835457041117320}
+  - component: {fileID: 108481828432753931}
+  m_Layer: 5
+  m_Name: Viewport
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1065819148498040535
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4074755975807166688}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5126671053675922475}
+  m_Father: {fileID: 6961385225631420064}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &457192596528073725
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4074755975807166688}
+  m_CullTransparentMesh: 1
+--- !u!114 &6883835457041117320
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4074755975807166688}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10917, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &108481828432753931
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4074755975807166688}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ShowMaskGraphic: 0
+--- !u!1 &4803712446439059557
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8763837148463987636}
+  - component: {fileID: 3787661792547879162}
+  - component: {fileID: 1730745708050668642}
+  - component: {fileID: 221180480123000713}
+  m_Layer: 5
+  m_Name: Scrollbar Vertical
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8763837148463987636
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4803712446439059557}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3017195406389831313}
+  m_Father: {fileID: 6961385225631420064}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 1, y: 1}
+--- !u!222 &3787661792547879162
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4803712446439059557}
+  m_CullTransparentMesh: 1
+--- !u!114 &1730745708050668642
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4803712446439059557}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &221180480123000713
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4803712446439059557}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a4db7a114972834c8e4117be1d82ba3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1559492482234651898}
+  m_HandleRect: {fileID: 3746545968163091893}
+  m_Direction: 2
+  m_Value: 0
+  m_Size: 1
+  m_NumberOfSteps: 0
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &4963274282767001143
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3746545968163091893}
+  - component: {fileID: 8293503657985931496}
+  - component: {fileID: 1559492482234651898}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3746545968163091893
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4963274282767001143}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3017195406389831313}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8293503657985931496
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4963274282767001143}
+  m_CullTransparentMesh: 1
+--- !u!114 &1559492482234651898
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4963274282767001143}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7897967578248868449
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5126671053675922475}
+  - component: {fileID: 1059404408605194623}
+  - component: {fileID: 3740809630349810688}
+  m_Layer: 5
+  m_Name: Content
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5126671053675922475
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7897967578248868449}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 506726505260495279}
+  m_Father: {fileID: 1065819148498040535}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &1059404408605194623
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7897967578248868449}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 0
+  m_VerticalFit: 2
+--- !u!114 &3740809630349810688
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7897967578248868449}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 10
+    m_Right: 10
+    m_Top: 10
+    m_Bottom: 10
+  m_ChildAlignment: 1
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0

--- a/Packages.Unity/Fantasy.Unity/Editor/Settings/FantasySettingsProvider.cs
+++ b/Packages.Unity/Fantasy.Unity/Editor/Settings/FantasySettingsProvider.cs
@@ -15,6 +15,8 @@ namespace Fantasy
         private SerializedProperty _uiGenerateSavePath;
         private SerializedProperty _hotUpdatePath;
         private SerializedProperty _hotUpdateAssemblyDefinitions;
+        private SerializedProperty _fantasyUIAutoRefFunction;
+        private SerializedProperty _fantasyUIAutoRefSettings;
         public FantasySettingsProvider() : base("Project/Fantasy Settings", SettingsScope.Project) { }
 
         public override void OnActivate(string searchContext, VisualElement rootElement)
@@ -37,6 +39,8 @@ namespace Fantasy
             _uiGenerateSavePath = _serializedObject.FindProperty("uiGenerateSavePath");
             _hotUpdatePath = _serializedObject.FindProperty("hotUpdatePath");
             _hotUpdateAssemblyDefinitions = _serializedObject.FindProperty("hotUpdateAssemblyDefinitions");
+            _fantasyUIAutoRefFunction = _serializedObject.FindProperty("fantasyUIAutoRefFunction");
+            _fantasyUIAutoRefSettings = _serializedObject.FindProperty("fantasyUIAutoRefSettings");
         }
 
         public override void OnGUI(string searchContext)
@@ -48,18 +52,21 @@ namespace Fantasy
 
             using (CreateSettingsWindowGUIScope())
             {
-                _serializedObject.Update();
+                _serializedObject!.Update();
                 
                 EditorGUI.BeginChangeCheck();
                 EditorGUILayout.PropertyField(_autoCopyAssembly);
                 EditorGUILayout.PropertyField(_uiGenerateSavePath);
                 EditorGUILayout.PropertyField(_hotUpdatePath);
                 EditorGUILayout.PropertyField(_hotUpdateAssemblyDefinitions);
+                EditorGUILayout.PropertyField(_fantasyUIAutoRefFunction);
+                EditorGUILayout.PropertyField(_fantasyUIAutoRefSettings);
                 
                 if (EditorGUI.EndChangeCheck())
                 {
                     _serializedObject.ApplyModifiedProperties();
                     FantasySettingsScriptableObject.Save();
+                    EditorApplication.RepaintHierarchyWindow();
                 }
                 
                 base.OnGUI(searchContext);

--- a/Packages.Unity/Fantasy.Unity/Editor/Settings/FantasySettingsScriptableObject.cs
+++ b/Packages.Unity/Fantasy.Unity/Editor/Settings/FantasySettingsScriptableObject.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
 using UnityEngine.Serialization;
@@ -5,19 +7,53 @@ using UnityEngine.Serialization;
 namespace Fantasy
 {
     [ScriptableObjectPath("ProjectSettings/FantasySettings.asset")]
-    public class FantasySettingsScriptableObject : ScriptableObjectSingleton<FantasySettingsScriptableObject>
+    public class FantasySettingsScriptableObject : ScriptableObjectSingleton<FantasySettingsScriptableObject>, ISerializationCallbackReceiver
     {
-        [FormerlySerializedAs("AutoCopyAssembly")] 
-        [Header("自动拷贝程序集到HotUpdatePath目录中")]
+        [FormerlySerializedAs("AutoCopyAssembly")] [Header("自动拷贝程序集到HotUpdatePath目录中")]
         public bool autoCopyAssembly = true;
-        [FormerlySerializedAs("UIGenerateSavePath")] 
-        [Header("UI生层代码路径")]
+
+        [FormerlySerializedAs("UIGenerateSavePath")] [Header("UI生层代码路径")]
         public string uiGenerateSavePath;
-        [FormerlySerializedAs("HotUpdatePath")] 
-        [Header("HotUpdate目录(Unity编译后会把所有HotUpdate程序集Copy一份到这个目录下)")]
+
+        [FormerlySerializedAs("HotUpdatePath")] [Header("HotUpdate目录(Unity编译后会把所有HotUpdate程序集Copy一份到这个目录下)")]
         public string hotUpdatePath;
-        [FormerlySerializedAs("HotUpdateAssemblyDefinitions")] 
-        [Header("HotUpdate程序集")]
+
+        [FormerlySerializedAs("HotUpdateAssemblyDefinitions")] [Header("HotUpdate程序集")]
         public AssemblyDefinitionAsset[] hotUpdateAssemblyDefinitions;
+
+        [FormerlySerializedAs("FantasyUIAutoRefFunction")] [Header("FantasyUI自动引用功能开启")]
+        public bool fantasyUIAutoRefFunction;
+
+        [FormerlySerializedAs("FantasyUIAutoRefSettings")] [Header("FantasyUI自动引用设置")] [SerializeField]
+        private FantasyUIRefData[] fantasyUIAutoRefSettings =
+        {
+            new() { key = "btn", value = "Button" },
+            new() { key = "img", value = "Image" },
+            new() { key = "input", value = "TMP_InputField, InputField" },
+            new() { key = "dropdown", value = "TMP_Dropdown" },
+            new() { key = "txt", value = "TextMeshProUGUI, Text" },
+            new() { key = "label", value = "TextMeshProUGUI, Text" },
+            new() { key = "rect", value = "RectTransform" },
+            new() { key = "tog", value = "Toggle" },
+            new() { key = "cg", value = "CanvasGroup" },
+            new() { key = "scroll", value = "FantasyVerticalScrollView, FantasyHorizontalScrollView, FantasyGridScrollView, ScrollRect" },
+        };
+
+        public readonly Dictionary<string, string> FantasyUIAutoRefSettings = new();
+
+        public void OnBeforeSerialize()
+        {
+        }
+
+        public void OnAfterDeserialize()
+        {
+            FantasyUIAutoRefSettings.Clear();
+            foreach (var kvp in fantasyUIAutoRefSettings)
+            {
+                if (string.IsNullOrEmpty(kvp.key) || string.IsNullOrEmpty(kvp.value))
+                    continue;
+                FantasyUIAutoRefSettings.TryAdd(kvp.key, kvp.value);
+            }
+        }
     }
 }

--- a/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/Core/FantasyEditorEventHelper.cs
+++ b/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/Core/FantasyEditorEventHelper.cs
@@ -1,0 +1,42 @@
+﻿#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+
+namespace Fantasy
+{
+    public static class FantasyEditorEventHelper
+    {
+        private static readonly Dictionary<int, Action> Actions = new();
+
+        public static void AddListener(int eventId, Action trigger)
+        {
+            Actions.TryAdd(eventId, default);
+            Actions[eventId] += trigger;
+        }
+
+        public static void RemoveListener(int eventId, Action trigger)
+        {
+            if (!Actions.ContainsKey(eventId))
+                return;
+            Actions[eventId] -= trigger;
+        }
+
+        public static void RemoveAllListener(int eventId)
+        {
+            if (Actions.ContainsKey(eventId))
+                Actions.Remove(eventId);
+        }
+
+        public static void ClearAll()
+        {
+            Actions.Clear();
+        }
+
+        public static void Trigger(int eventId)
+        {
+            if (Actions.TryGetValue(eventId, out var action))
+                action?.Invoke();
+        }
+    }
+}
+#endif

--- a/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/Core/FantasyRef.cs
+++ b/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/Core/FantasyRef.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace Fantasy
+{
+    public class FantasyRef : MonoBehaviour, ISerializationCallbackReceiver
+    {
+        public bool isUI = true;
+        public string moduleName;
+        
+        public string componentName;
+        
+        public List<FantasyUIData> list = new();
+        private readonly Dictionary<string, Object> _referenceDic = new();
+        
+        public T GetReference<T>(string key) where T : Object
+        {
+            return _referenceDic.TryGetValue(key, out var obj) ? (T)obj : null;
+        }
+
+        public Object GetReference(string key)
+        {
+            return _referenceDic.GetValueOrDefault(key);
+        }
+
+        public void OnAfterDeserialize()
+        {
+            _referenceDic.Clear();
+			
+            foreach (var referenceCollectorData in list)
+            {
+                if (_referenceDic.ContainsKey(referenceCollectorData.key))
+                {
+                    continue;
+                }
+				
+                _referenceDic.Add(referenceCollectorData.key, referenceCollectorData.gameObject);
+            }
+        }
+		
+        public void OnBeforeSerialize() { }
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/Core/FantasyUI.cs
+++ b/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/Core/FantasyUI.cs
@@ -11,7 +11,7 @@ namespace Fantasy
 	public class FantasyUIData
 	{
 		public string key;
-		public UnityEngine.Object gameObject;
+		public Object gameObject;
 	}
 	
 	public class FantasyUIDataComparer : IComparer<FantasyUIData>
@@ -38,7 +38,7 @@ namespace Fantasy
 
 		public Object GetReference(string key)
 		{
-			return _referenceDic.TryGetValue(key, out var obj) ? obj : null;
+			return _referenceDic.GetValueOrDefault(key);
 		}
 
 		public void OnAfterDeserialize()

--- a/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/Core/FantasyUIRef.cs
+++ b/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/Core/FantasyUIRef.cs
@@ -1,0 +1,10 @@
+﻿namespace Fantasy
+{
+    public class FantasyUIRef : FantasyRef
+    {
+        public string assetName;
+        public string bundleName;
+
+        public UILayer uiLayer = UILayer.BaseRoot;
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/Core/SubUI.cs
+++ b/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/Core/SubUI.cs
@@ -1,0 +1,62 @@
+﻿using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Fantasy
+{
+    public abstract class SubUI : Entity
+    {
+        public GameObject GameObject;
+        public abstract void Initialize();
+        
+        public override void Dispose()
+        {
+            if (IsDisposed)
+            {
+                return;
+            }
+            
+            Object.Destroy(GameObject);
+
+            GameObject = null;            
+            base.Dispose();
+        }
+        
+        public T AddComponent<T>(UILayer layer = UILayer.None) where T : UI, new()
+        {
+            var uiComponent = UIComponent.Instance.Create<T>(layer, false);
+            AddComponent(uiComponent);
+            EntitiesSystem.Instance.Awake(uiComponent);
+            EntitiesSystem.Instance.StartUpdate(uiComponent);
+            return uiComponent;
+        }
+
+        public async FTask<T> AddComponentAsync<T>(UILayer layer = UILayer.None) where T : UI, new()
+        {
+            var uiComponent = await UIComponent.Instance.CreateAsync<T>(layer, false);
+            AddComponent(uiComponent);
+            EntitiesSystem.Instance.Awake(uiComponent);
+            EntitiesSystem.Instance.StartUpdate(uiComponent);
+            return uiComponent;
+        }
+        
+        public void Hide()
+        {
+            if (GameObject == null || !GameObject.activeSelf)
+            {
+                return;
+            }
+
+            GameObject.SetActive(false);
+        }
+
+        public void Show()
+        {
+            if (GameObject == null || GameObject.activeSelf)
+            {
+                return;
+            }
+
+            GameObject.SetActive(true);
+        }
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/FantasyScrollView/FantasyGridScrollView.cs
+++ b/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/FantasyScrollView/FantasyGridScrollView.cs
@@ -1,0 +1,737 @@
+﻿using System;
+using System.Collections.Generic;
+using DG.Tweening;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Fantasy
+{
+    [DisallowMultipleComponent]
+    public class FantasyGridScrollView : MonoBehaviour, IFantasyScrollView
+    {
+        public ScrollRect scrollRect;
+        public FantasyRef itemTemplate;
+        public GridLayoutGroup gridLayoutGroup;
+        public ContentSizeFitter contentSizeFitter;
+
+        private RectTransform _contentRect;
+        private RectTransform _viewportRect;
+        private RectTransform _scrollViewRect;
+
+        private readonly Queue<int> _pools = new();
+        private readonly List<GameObject> _items = new();
+        private readonly Dictionary<int, int> _showingItems = new();
+        private readonly HashSet<int> _toShow = new();
+        private readonly List<int> _toRemove = new();
+
+        private int _itemNum; // 当前item元素的总数
+        private int _hCount; // 水平item的个数
+        private int _vCount; // 竖直item的个数
+
+
+        private void Awake()
+        {
+            if (contentSizeFitter)
+                contentSizeFitter.enabled = false;
+            gridLayoutGroup.enabled = false;
+            itemTemplate.gameObject.SetActive(false);
+            _scrollViewRect = scrollRect.transform as RectTransform;
+            _viewportRect = scrollRect.viewport;
+            _contentRect = scrollRect.content;
+            _contentRect.anchorMax = Vector2.up;
+            _contentRect.anchorMin = Vector2.up;
+            scrollRect.onValueChanged.AddListener(_ => { RefreshViewport(); });
+
+#if UNITY_EDITOR
+            _previousContentWidth = _contentRect.rect.width;
+            // 这里是为了让LayoutGroup在运行中发生更改时，能够实时反应到表现上
+            if (!gridLayoutGroup)
+                return;
+            _layoutGroupInstanceId = gridLayoutGroup.GetInstanceID();
+            _contentSizeFitterInstanceId = contentSizeFitter.GetInstanceID();
+            FantasyEditorEventHelper.AddListener(_layoutGroupInstanceId, RefreshWhenPropertyChanged);
+            FantasyEditorEventHelper.AddListener(_contentSizeFitterInstanceId, RefreshWhenPropertyChanged);
+#endif
+        }
+
+#if UNITY_EDITOR
+        private int _layoutGroupInstanceId;
+        private int _contentSizeFitterInstanceId;
+
+        private void OnDestroy()
+        {
+            FantasyEditorEventHelper.RemoveAllListener(_layoutGroupInstanceId);
+            FantasyEditorEventHelper.RemoveAllListener(_contentSizeFitterInstanceId);
+        }
+
+        private void RefreshWhenPropertyChanged()
+        {
+            SetItemNum(_itemNum);
+            RefreshViewport();
+        }
+
+        private float _previousContentWidth;
+        private void Update()
+        {
+            if (Math.Abs(_previousContentWidth - _contentRect.rect.width) > 0.01f)
+            {
+                _previousContentWidth = _contentRect.rect.width;
+                RefreshWhenPropertyChanged();
+            }
+        }
+#endif
+
+        private void RefreshViewport(bool refreshAll = false)
+        {
+            var contentRectAnchoredPosition = _contentRect.anchoredPosition;
+            var upperLeftPos = new Vector2(-contentRectAnchoredPosition.x, contentRectAnchoredPosition.y);
+            var viewportSize = GetViewportSize();
+            var lowerRightPos = upperLeftPos + new Vector2(viewportSize.x, viewportSize.y);
+
+
+            var begin = GetIdxAfterPosition(upperLeftPos);
+            var end = GetIdxBeforePosition(lowerRightPos);
+
+            if (begin.x == -1 || begin.y == -1 || end.x == -1 || end.y == -1)
+            {
+                // 没有item在范围内
+                foreach (var (idx, itemIdx) in _showingItems)
+                {
+                    Return(itemIdx);
+                    OnScrollItemHide?.Invoke(idx, itemIdx);
+                }
+
+                _showingItems.Clear();
+                return;
+            }
+
+            _toRemove.Clear();
+            foreach (var (idx, itemIdx) in _showingItems)
+            {
+                if (_toShow.Contains(idx))
+                    continue;
+                Return(itemIdx);
+                OnScrollItemHide?.Invoke(idx, itemIdx);
+                _toRemove.Add(idx);
+            }
+
+            foreach (var idx in _toRemove)
+            {
+                _showingItems.Remove(idx);
+            }
+
+            _toRemove.Clear();
+
+            _toShow.Clear();
+            for (int i = begin.x; i <= end.x; i++)
+            {
+                for (int j = begin.y; j <= end.y; j++)
+                {
+                    var idx = GetItemIdx(j, i);
+                    if (idx < 0 || idx >= _itemNum)
+                        continue;
+                    _toShow.Add(idx);
+                    if (_showingItems.TryGetValue(idx, out var itemIdx)) // 已经在显示中
+                    {
+                        PlaceItem(itemIdx, idx);
+                        if (refreshAll)
+                            OnScrollItemShow?.Invoke(idx, itemIdx);
+                    }
+                    else
+                    {
+                        itemIdx = Rent();
+                        PlaceItem(itemIdx, idx);
+                        OnScrollItemShow?.Invoke(idx, itemIdx);
+                        _showingItems.Add(idx, itemIdx);
+                    }
+                }
+            }
+
+            _toShow.Clear();
+        }
+
+        private void PlaceItem(int itemIdx, int idx)
+        {
+            var (vIdx, hIdx, xPos, yPos) = GetItemPosition(idx);
+            if (vIdx < 0 || hIdx < 0)
+                return;
+            var item = _items[itemIdx];
+            item.name = $"v{vIdx}_h{hIdx}";
+            var itemRect = (RectTransform)item.transform;
+            itemRect.anchorMin = Vector2.up;
+            itemRect.anchorMax = Vector2.up;
+            itemRect.pivot = Vector2.up;
+            itemRect.sizeDelta = gridLayoutGroup.cellSize;
+            itemRect.anchoredPosition = new Vector2(xPos, -yPos);
+        }
+
+        #region 移动
+
+        public void MoveToBegin(float duration, Action onCompleted = null)
+        {
+            MoveToIdx(0, duration, onCompleted);
+        }
+
+        public void MoveToEnd(float duration, Action onCompleted = null)
+        {
+            MoveToIdx(_itemNum - 1, duration, onCompleted);
+        }
+
+        public void MoveToIdx(int idx, float duration, Action onCompleted = null)
+        {
+            if (_itemNum <= 0 || idx < 0 || idx + 1 > _itemNum)
+            {
+                Log.Warning($"不可移动到指定索引 {idx}");
+                return;
+            }
+
+            var (_, _, xBegin, yBegin) = GetItemPosition(idx);
+            var cellSize = gridLayoutGroup.cellSize;
+            var (xEnd, yEnd) = (xBegin + cellSize.x, yBegin + cellSize.y);
+
+            var contentRectAnchoredPosition = _contentRect.anchoredPosition;
+            var viewportSize = GetViewportSize();
+            var upperLeftPos = new Vector2(-contentRectAnchoredPosition.x, contentRectAnchoredPosition.y);
+            var lowerRightPos = upperLeftPos + new Vector2(viewportSize.x, viewportSize.y);
+
+            if (xBegin >= upperLeftPos.x && yBegin >= upperLeftPos.y && xEnd <= lowerRightPos.x && yEnd <= lowerRightPos.y) // 在区域内
+                onCompleted?.Invoke();
+            else if (xBegin < upperLeftPos.x && yBegin < upperLeftPos.y) // 左上
+                MoveToContentPos(new Vector2(-xBegin, yBegin), duration, onCompleted);
+            else if (xBegin < upperLeftPos.x && yEnd > lowerRightPos.y) // 左下
+                MoveToContentPos(new Vector2(-xBegin, yEnd - viewportSize.y), duration, onCompleted);
+            else if (xEnd > lowerRightPos.x && yBegin < upperLeftPos.y) // 右上
+                MoveToContentPos(new Vector2(-(xEnd - viewportSize.x), yBegin), duration, onCompleted);
+            else if (xEnd > lowerRightPos.x && yEnd > lowerRightPos.y) // 右下
+                MoveToContentPos(new Vector2(-(xEnd - viewportSize.x), yEnd - viewportSize.y), duration, onCompleted);
+            else if (xBegin < upperLeftPos.x) // 左
+                MoveToContentPosX(-xBegin, duration, onCompleted);
+            else if (xEnd > lowerRightPos.x) // 右
+                MoveToContentPosX(-(xEnd - viewportSize.x), duration, onCompleted);
+            else if (yBegin < upperLeftPos.y) // 上
+                MoveToContentPosY(yBegin, duration, onCompleted);
+            else if (yEnd > lowerRightPos.y) // 下
+                MoveToContentPosY(yEnd - viewportSize.y, duration, onCompleted);
+            else // 包围
+                MoveToContentPos(new Vector2(-xBegin, yBegin), duration, onCompleted);
+        }
+
+        private void MoveToContentPos(Vector3 pos, float duration, Action onCompleted = null)
+        {
+            var elasticity = scrollRect.elasticity;
+            scrollRect.elasticity = 0;
+            var movementType = scrollRect.movementType;
+            scrollRect.movementType = ScrollRect.MovementType.Clamped;
+            _contentRect.DOLocalMove(pos, duration).OnComplete(() =>
+            {
+                scrollRect.StopMovement();
+                scrollRect.movementType = movementType;
+                scrollRect.elasticity = elasticity;
+                onCompleted?.Invoke();
+            });
+        }
+
+        private void MoveToContentPosX(float pos, float duration, Action onCompleted = null)
+        {
+            var elasticity = scrollRect.elasticity;
+            scrollRect.elasticity = 0;
+            var movementType = scrollRect.movementType;
+            scrollRect.movementType = ScrollRect.MovementType.Clamped;
+            _contentRect.DOLocalMoveX(pos, duration).OnComplete(() =>
+            {
+                scrollRect.StopMovement();
+                scrollRect.movementType = movementType;
+                scrollRect.elasticity = elasticity;
+                onCompleted?.Invoke();
+            });
+        }
+
+        private void MoveToContentPosY(float pos, float duration, Action onCompleted = null)
+        {
+            var elasticity = scrollRect.elasticity;
+            scrollRect.elasticity = 0;
+            var movementType = scrollRect.movementType;
+            scrollRect.movementType = ScrollRect.MovementType.Clamped;
+            _contentRect.DOLocalMoveY(pos, duration).OnComplete(() =>
+            {
+                scrollRect.StopMovement();
+                scrollRect.movementType = movementType;
+                scrollRect.elasticity = elasticity;
+                onCompleted?.Invoke();
+            });
+        }
+
+        #endregion
+
+        private Vector2 GetViewportSize()
+        {
+            var viewportRect = _viewportRect.rect;
+            var viewportWidth = viewportRect.width;
+            var viewportHeight = viewportRect.height;
+            if (viewportWidth == 0)
+            {
+                viewportWidth = _scrollViewRect.rect.width;
+                var scrollBar = scrollRect.verticalScrollbar;
+                if (!scrollBar)
+                    viewportWidth -= ((RectTransform)scrollBar.transform).rect.width;
+            }
+
+            if (viewportHeight == 0)
+            {
+                viewportHeight = _scrollViewRect.rect.height;
+                var scrollBar = scrollRect.horizontalScrollbar;
+                if (!scrollBar)
+                    viewportHeight -= ((RectTransform)scrollBar.transform).rect.height;
+            }
+
+            return new Vector2(viewportWidth, viewportHeight);
+        }
+
+        public void SetItemNum(int itemNum)
+        {
+            if (itemNum <= 0)
+            {
+                _itemNum = 0;
+                _vCount = 0;
+                _hCount = 0;
+                if (contentSizeFitter.horizontalFit != ContentSizeFitter.FitMode.Unconstrained)
+                {
+                    _contentRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 0);
+                }
+
+                if (contentSizeFitter.verticalFit != ContentSizeFitter.FitMode.Unconstrained)
+                {
+                    _contentRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 0);
+                }
+
+                return;
+            }
+
+            _itemNum = itemNum;
+            var horizontalFit = contentSizeFitter.horizontalFit;
+            var verticalFit = contentSizeFitter.verticalFit;
+            var padding = gridLayoutGroup.padding;
+            var spacing = gridLayoutGroup.spacing;
+            var cellSize = gridLayoutGroup.cellSize;
+            var constraint = gridLayoutGroup.constraint;
+
+            int v_count;
+            int h_count;
+            switch (constraint)
+            {
+                case GridLayoutGroup.Constraint.Flexible:
+                {
+                    switch (horizontalFit)
+                    {
+                        case (ContentSizeFitter.FitMode.Unconstrained):
+                        {
+                            var width = _contentRect.rect.width - padding.horizontal;
+                            if (width < cellSize.x)
+                                h_count = 1;
+                            else
+                                h_count = Mathf.FloorToInt((width - cellSize.x) / (cellSize.x + spacing.x)) + 1;
+
+                            v_count = itemNum / h_count + (itemNum % h_count > 0 ? 1 : 0);
+                            if (verticalFit != ContentSizeFitter.FitMode.Unconstrained)
+                                _contentRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, padding.vertical + cellSize.y * v_count + spacing.y * (v_count - 1));
+                            break;
+                        }
+                        case (ContentSizeFitter.FitMode.MinSize):
+                        {
+                            h_count = 1;
+                            v_count = itemNum;
+                            _contentRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, padding.horizontal + cellSize.x);
+                            if (verticalFit != ContentSizeFitter.FitMode.Unconstrained)
+                                _contentRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, padding.vertical + cellSize.y * v_count + spacing.y * (v_count - 1));
+                            break;
+                        }
+                        case (ContentSizeFitter.FitMode.PreferredSize):
+                        {
+                            h_count = Mathf.CeilToInt(Mathf.Sqrt(itemNum));
+                            v_count = itemNum / h_count + (itemNum % h_count > 0 ? 1 : 0);
+                            _contentRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, padding.horizontal + cellSize.x * h_count + spacing.x * (h_count - 1));
+                            if (verticalFit != ContentSizeFitter.FitMode.Unconstrained)
+                                _contentRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, padding.vertical + cellSize.y * v_count + spacing.y * (v_count - 1));
+                            break;
+                        }
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+
+                    break;
+                }
+                case GridLayoutGroup.Constraint.FixedColumnCount:
+                {
+                    h_count = gridLayoutGroup.constraintCount;
+                    v_count = itemNum / h_count + (itemNum % h_count > 0 ? 1 : 0);
+                    if (horizontalFit != ContentSizeFitter.FitMode.Unconstrained)
+                        _contentRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, padding.horizontal + cellSize.x * h_count + spacing.x * (h_count - 1));
+                    if (verticalFit != ContentSizeFitter.FitMode.Unconstrained)
+                        _contentRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, padding.vertical + cellSize.y * v_count + spacing.y * (v_count - 1));
+                    break;
+                }
+                case GridLayoutGroup.Constraint.FixedRowCount:
+                {
+                    v_count = gridLayoutGroup.constraintCount;
+                    h_count = itemNum / v_count + (itemNum % v_count > 0 ? 1 : 0);
+                    if (horizontalFit != ContentSizeFitter.FitMode.Unconstrained)
+                        _contentRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, padding.horizontal + cellSize.x * h_count + spacing.x * (h_count - 1));
+                    if (verticalFit != ContentSizeFitter.FitMode.Unconstrained)
+                        _contentRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, padding.vertical + cellSize.y * v_count + spacing.y * (v_count - 1));
+                    break;
+                }
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            _vCount = v_count;
+            _hCount = h_count;
+        }
+
+        public void Refresh()
+        {
+            RefreshViewport(true);
+        }
+
+        public OnScrollItemShow OnScrollItemShow { get; set; }
+        public OnScrollItemCreate OnScrollItemCreate { get; set; }
+        public OnScrollItemHide OnScrollItemHide { get; set; }
+
+
+        #region Pool
+
+        private int Rent()
+        {
+            GameObject item;
+            if (!_pools.TryDequeue(out var itemIdx))
+            {
+                item = Instantiate(itemTemplate.gameObject, _contentRect);
+                _items.Add(item);
+                itemIdx = _items.Count - 1;
+                OnScrollItemCreate?.Invoke(item, itemIdx);
+            }
+            else
+            {
+                item = _items[itemIdx];
+            }
+
+            item.SetActive(true);
+            return itemIdx;
+        }
+
+        private void Return(int itemIdx)
+        {
+            var item = _items[itemIdx];
+            item.name = "poolItem";
+            item.SetActive(false);
+            _pools.Enqueue(itemIdx);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// 获取某个Idx的位置信息
+        /// </summary>
+        /// <param name="idx">Item数据索引</param>
+        private (int vIdx, int hIdx, float xPos, float yPos) GetItemPosition(int idx)
+        {
+            int vIdx;
+            int hIdx;
+            if (idx < 0 || idx >= _itemNum)
+            {
+                return (-1, -1, 0, 0);
+            }
+
+            var startCorner = gridLayoutGroup.startCorner;
+            var startAxis = gridLayoutGroup.startAxis;
+            var constrain = gridLayoutGroup.constraint;
+            var constrainCount = gridLayoutGroup.constraintCount;
+
+            var h_count = _hCount;
+            var v_count = _vCount;
+
+
+            switch (startCorner)
+            {
+                case GridLayoutGroup.Corner.UpperLeft when startAxis == GridLayoutGroup.Axis.Horizontal:
+                    (vIdx, hIdx) = (idx / h_count, idx % h_count);
+                    break;
+                case GridLayoutGroup.Corner.UpperLeft when startAxis == GridLayoutGroup.Axis.Vertical:
+                    (vIdx, hIdx) = (idx % v_count, idx / v_count);
+                    break;
+                case GridLayoutGroup.Corner.UpperRight when startAxis == GridLayoutGroup.Axis.Horizontal:
+                    (vIdx, hIdx) = (idx / h_count, h_count - 1 - idx % h_count);
+                    break;
+                case GridLayoutGroup.Corner.UpperRight when startAxis == GridLayoutGroup.Axis.Vertical:
+                    (vIdx, hIdx) = (idx % v_count, h_count - 1 - idx / v_count);
+                    break;
+                case GridLayoutGroup.Corner.LowerLeft when startAxis == GridLayoutGroup.Axis.Horizontal:
+                    (vIdx, hIdx) = (v_count - 1 - idx / h_count, idx % h_count);
+                    break;
+                case GridLayoutGroup.Corner.LowerLeft when startAxis == GridLayoutGroup.Axis.Vertical:
+                    (vIdx, hIdx) = (v_count - 1 - idx % v_count, idx / v_count);
+                    break;
+                case GridLayoutGroup.Corner.LowerRight when startAxis == GridLayoutGroup.Axis.Horizontal:
+                    (vIdx, hIdx) = (v_count - 1 - idx / h_count, h_count - 1 - idx % h_count);
+                    break;
+                case GridLayoutGroup.Corner.LowerRight when startAxis == GridLayoutGroup.Axis.Vertical:
+                    (vIdx, hIdx) = (v_count - 1 - idx % v_count, h_count - 1 - idx / v_count);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            // ReSharper disable once ConvertIfStatementToSwitchStatement
+            if (constrain == GridLayoutGroup.Constraint.FixedColumnCount && startAxis == GridLayoutGroup.Axis.Vertical && _itemNum > constrainCount)
+            {
+                var remain = _itemNum - constrainCount;
+                var value = remain / (v_count - 1) + (remain % (v_count - 1) == 0 ? 0 : 1);
+                var domain = value + remain;
+                // 最后的这几个item需要补位
+                if (idx >= domain)
+                {
+                    switch (startCorner)
+                    {
+                        case GridLayoutGroup.Corner.UpperLeft:
+                            vIdx = 0;
+                            hIdx = value + idx - domain;
+                            break;
+                        case GridLayoutGroup.Corner.UpperRight:
+                            vIdx = 0;
+                            hIdx = h_count - 1 - (value + idx - domain);
+                            break;
+                        case GridLayoutGroup.Corner.LowerLeft:
+                            vIdx = _vCount - 1;
+                            hIdx = value + idx - domain;
+                            break;
+                        case GridLayoutGroup.Corner.LowerRight:
+                            vIdx = _vCount - 1;
+                            hIdx = h_count - 1 - (value + idx - domain);
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+            }
+            else if (constrain == GridLayoutGroup.Constraint.FixedRowCount && startAxis == GridLayoutGroup.Axis.Horizontal && _itemNum > constrainCount)
+            {
+                var remain = _itemNum - constrainCount;
+                var value = remain / (h_count - 1) + (remain % (h_count - 1) == 0 ? 0 : 1);
+                var domain = value + remain;
+                // 最后的这几个item需要补位
+                if (idx >= domain)
+                {
+                    switch (startCorner)
+                    {
+                        case GridLayoutGroup.Corner.UpperLeft:
+                            hIdx = 0;
+                            vIdx = value + idx - domain;
+                            break;
+                        case GridLayoutGroup.Corner.LowerLeft:
+                            hIdx = 0;
+                            vIdx = v_count - 1 - (value + idx - domain);
+                            break;
+                        case GridLayoutGroup.Corner.UpperRight:
+                            hIdx = h_count - 1;
+                            vIdx = value + idx - domain;
+                            break;
+                        case GridLayoutGroup.Corner.LowerRight:
+                            hIdx = h_count - 1;
+                            vIdx = v_count - 1 - (value + idx - domain);
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+                }
+            }
+
+            var pos = GetItemPosition(hIdx, vIdx);
+
+            // 此处返回的坐标值的坐标系Y轴正方向朝下
+            return (vIdx, hIdx, pos.x, pos.y);
+        }
+
+        private Vector2 GetItemPosition(int hIdx, int vIdx)
+        {
+            if (hIdx < 0 || vIdx < 0 || _hCount == 0 || _vCount == 0 || hIdx >= _hCount || vIdx >= _vCount)
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            var padding = gridLayoutGroup.padding;
+            var spacing = gridLayoutGroup.spacing;
+            var cellSize = gridLayoutGroup.cellSize;
+            var childAlignment = gridLayoutGroup.childAlignment;
+            var constraint = gridLayoutGroup.constraint;
+
+            var h_count = _hCount;
+            var v_count = _vCount;
+            float xPos;
+            float yPos;
+            switch (constraint)
+            {
+                case GridLayoutGroup.Constraint.Flexible:
+                {
+                    xPos = padding.left + hIdx * (cellSize.x + spacing.x);
+                    yPos = padding.top + vIdx * (cellSize.y + spacing.y);
+                    break;
+                }
+                case GridLayoutGroup.Constraint.FixedColumnCount or GridLayoutGroup.Constraint.FixedRowCount:
+                {
+                    var contentRect = _contentRect.rect;
+
+                    switch (childAlignment)
+                    {
+                        case TextAnchor.UpperLeft:
+                            (xPos, yPos) = (LeftPosX(), UpperPosY());
+                            break;
+                        case TextAnchor.UpperCenter:
+                            (xPos, yPos) = (CenterPosX(), UpperPosY());
+                            break;
+                        case TextAnchor.UpperRight:
+                            (xPos, yPos) = (RightPosX(), UpperPosY());
+                            break;
+                        case TextAnchor.MiddleLeft:
+                            (xPos, yPos) = (LeftPosX(), MiddlePosY());
+                            break;
+                        case TextAnchor.MiddleCenter:
+                            (xPos, yPos) = (CenterPosX(), MiddlePosY());
+                            break;
+                        case TextAnchor.MiddleRight:
+                            (xPos, yPos) = (RightPosX(), MiddlePosY());
+                            break;
+                        case TextAnchor.LowerLeft:
+                            (xPos, yPos) = (LeftPosX(), LowerPosY());
+                            break;
+                        case TextAnchor.LowerCenter:
+                            (xPos, yPos) = (CenterPosX(), LowerPosY());
+                            break;
+                        case TextAnchor.LowerRight:
+                            (xPos, yPos) = (RightPosX(), LowerPosY());
+                            break;
+                        default:
+                            throw new ArgumentOutOfRangeException();
+                    }
+
+                    break;
+
+                    float LeftPosX() => padding.left + hIdx * (cellSize.x + spacing.x);
+                    float CenterPosX() => contentRect.width / 2 - (cellSize.x * h_count + spacing.x * (h_count - 1)) / 2 + hIdx * (cellSize.x + spacing.x);
+                    float RightPosX() => contentRect.width - padding.right - (cellSize.x * h_count + spacing.x * (h_count - 1)) + hIdx * (cellSize.x + spacing.x);
+                    float UpperPosY() => padding.top + vIdx * (cellSize.y + spacing.y);
+                    float MiddlePosY() => contentRect.height / 2 - (cellSize.y * v_count + spacing.y * (v_count - 1)) / 2 + vIdx * (cellSize.y + spacing.y);
+                    float LowerPosY() => contentRect.height - padding.bottom - (cellSize.y * v_count + spacing.y * (v_count - 1)) + vIdx * (cellSize.y + spacing.y);
+                }
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            return new Vector2(xPos, yPos);
+        }
+
+        private int GetItemIdx(int vIdx, int hIdx)
+        {
+            if (vIdx < 0 || hIdx < 0 || vIdx >= _vCount || hIdx >= _hCount)
+                return -1;
+
+            var startAxis = gridLayoutGroup.startAxis;
+            var startCorner = gridLayoutGroup.startCorner;
+            var idx = startCorner switch
+            {
+                GridLayoutGroup.Corner.UpperLeft when startAxis == GridLayoutGroup.Axis.Horizontal => _hCount * vIdx + hIdx,
+                GridLayoutGroup.Corner.UpperLeft when startAxis == GridLayoutGroup.Axis.Vertical => _vCount * hIdx + vIdx,
+                GridLayoutGroup.Corner.UpperRight when startAxis == GridLayoutGroup.Axis.Horizontal => _hCount * vIdx + (_hCount - 1 - hIdx),
+                GridLayoutGroup.Corner.UpperRight when startAxis == GridLayoutGroup.Axis.Vertical => _vCount * (_hCount - 1 - hIdx) + vIdx,
+                GridLayoutGroup.Corner.LowerLeft when startAxis == GridLayoutGroup.Axis.Horizontal => _hCount * (_vCount - 1 - vIdx) + hIdx,
+                GridLayoutGroup.Corner.LowerLeft when startAxis == GridLayoutGroup.Axis.Vertical => _vCount * hIdx + (_vCount - 1 - vIdx),
+                GridLayoutGroup.Corner.LowerRight when startAxis == GridLayoutGroup.Axis.Horizontal => _hCount * (_vCount - 1 - vIdx) + (_hCount - 1 - hIdx),
+                GridLayoutGroup.Corner.LowerRight when startAxis == GridLayoutGroup.Axis.Vertical => _vCount * (_hCount - 1 - hIdx) + (_vCount - 1 - vIdx),
+                _ => throw new ArgumentOutOfRangeException()
+            };
+
+            return idx;
+        }
+
+        private Vector2Int GetIdxAfterPosition(Vector2 position)
+        {
+            if (_itemNum == 0)
+                return new Vector2Int(-1, -1);
+
+            int x;
+            int y;
+            var xPos = position.x;
+            var yPos = position.y;
+
+            var cellSize = gridLayoutGroup.cellSize;
+            var spacing = gridLayoutGroup.spacing;
+
+            var upperLeftPos = GetItemPosition(0, 0);
+            var lowerRightPos = GetItemPosition(_hCount - 1, _vCount - 1);
+            lowerRightPos += cellSize;
+            if (xPos <= upperLeftPos.x)
+            {
+                x = 0;
+            }
+            else if (xPos >= lowerRightPos.x)
+            {
+                x = -1;
+            }
+            else
+            {
+                var value = lowerRightPos.x - xPos;
+                x = _hCount - 1 - Mathf.FloorToInt(value / (cellSize.x + spacing.x));
+            }
+
+            if (yPos <= upperLeftPos.y)
+                y = 0;
+            else if (yPos >= lowerRightPos.y)
+                y = -1;
+            else
+            {
+                var value = lowerRightPos.y - yPos;
+                y = _vCount - 1 - Mathf.FloorToInt(value / (cellSize.y + spacing.y));
+            }
+
+            return new Vector2Int(x, y);
+        }
+
+        private Vector2Int GetIdxBeforePosition(Vector2 position)
+        {
+            if (_itemNum == 0)
+                return new Vector2Int(-1, -1);
+
+            int x;
+            int y;
+            var xPos = position.x;
+            var yPos = position.y;
+
+            var cellSize = gridLayoutGroup.cellSize;
+            var spacing = gridLayoutGroup.spacing;
+
+            var upperLeftPos = GetItemPosition(0, 0);
+            var lowerRightPos = GetItemPosition(_hCount - 1, _vCount - 1);
+            lowerRightPos += cellSize;
+            if (xPos <= upperLeftPos.x)
+                x = -1;
+            else if (xPos >= lowerRightPos.x)
+                x = _hCount - 1;
+            else
+            {
+                var value = xPos - upperLeftPos.x;
+                x = Mathf.FloorToInt(value / (cellSize.x + spacing.x));
+            }
+
+            if (yPos <= upperLeftPos.y)
+                y = -1;
+            else if (yPos >= lowerRightPos.y)
+                y = _vCount - 1;
+            else
+            {
+                var value = yPos - upperLeftPos.y;
+                y = Mathf.FloorToInt(value / (cellSize.y + spacing.y));
+            }
+
+            return new Vector2Int(x, y);
+        }
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/FantasyScrollView/FantasyHorizontalScrollView.cs
+++ b/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/FantasyScrollView/FantasyHorizontalScrollView.cs
@@ -1,0 +1,457 @@
+﻿using System;
+using System.Collections.Generic;
+using DG.Tweening;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Fantasy
+{
+    /// <summary>
+    /// 循环复用滑动列表（水平滑动）
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class FantasyHorizontalScrollView : MonoBehaviour, IFantasyScrollView
+    {
+        public ScrollRect scrollRect;
+        public FantasyRef itemTemplate;
+        public HorizontalLayoutGroup horizontalLayoutGroup;
+        public ContentSizeFitter contentSizeFitter;
+
+        private RectTransform _contentRect;
+        private RectTransform _itemTemplateRect;
+        private RectTransform _viewportRect;
+        private RectTransform _scrollViewRect;
+
+        private readonly float[] _slidingPosition = new float[2];
+        private readonly int[] _slidingIdx = { -1, -1 };
+        private readonly int[] _previousIdx = { -1, -1 };
+        private readonly LinkedList<int> _showingItems = new();
+        private readonly Queue<int> _pools = new();
+        private readonly List<GameObject> _items = new();
+
+        public OnScrollItemShow OnScrollItemShow { get; set; }
+        public OnScrollItemCreate OnScrollItemCreate { get; set; }
+        public OnScrollItemHide OnScrollItemHide { get; set; }
+
+        private int _itemNum;
+
+        private void Awake()
+        {
+            if (contentSizeFitter)
+                contentSizeFitter.enabled = false;
+            horizontalLayoutGroup.enabled = false;
+
+            itemTemplate.gameObject.SetActive(false);
+            _scrollViewRect = scrollRect.transform as RectTransform;
+            _contentRect = scrollRect.content;
+            _viewportRect = scrollRect.viewport;
+            _itemTemplateRect = itemTemplate.transform as RectTransform;
+            scrollRect.vertical = false;
+            scrollRect.horizontal = true;
+            _contentRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 0);
+            scrollRect.onValueChanged.AddListener(_ => RefreshViewport());
+#if UNITY_EDITOR
+            // 这里是为了让LayoutGroup在运行中发生更改时，能够实时反应到表现上
+            if (!horizontalLayoutGroup)
+                return;
+            _layoutGroupInstanceId = horizontalLayoutGroup.GetInstanceID();
+            FantasyEditorEventHelper.AddListener(_layoutGroupInstanceId, () =>
+            {
+                SetItemNum(_itemNum);
+                Refresh();
+            });
+#endif
+        }
+
+#if UNITY_EDITOR
+        private int _layoutGroupInstanceId;
+        private void OnDestroy()
+        {
+            FantasyEditorEventHelper.RemoveAllListener(_layoutGroupInstanceId);
+        }
+#endif
+
+        /// <summary>
+        /// 刷新显示区域的元素
+        /// </summary>
+        /// <param name="refreshAll">刷新之前已经展示的元素</param>
+        private void RefreshViewport(bool refreshAll = false)
+        {
+            // 计算当前content中显示的区域范围
+            float viewportWidth = _viewportRect.rect.width;
+            if (viewportWidth == 0)
+                viewportWidth = _scrollViewRect.rect.width;
+            float contentWidth = _contentRect.rect.width;
+            _slidingPosition[0] = Mathf.Max(0, -_contentRect.anchoredPosition.x);
+            _slidingPosition[1] = Mathf.Min(contentWidth, -_contentRect.anchoredPosition.x + viewportWidth);
+
+            // 计算需要显示的数据索引
+            var padding = horizontalLayoutGroup.padding;
+            var spacing = horizontalLayoutGroup.spacing;
+            var childAlignment = horizontalLayoutGroup.childAlignment;
+            var templateWidth = _itemTemplateRect.rect.width;
+
+            // 记录上一次展示的item
+            _previousIdx[0] = _slidingIdx[0];
+            _previousIdx[1] = _slidingIdx[1];
+            if (_slidingPosition[1] <= _slidingPosition[0])
+            {
+                // 没有需要显示的数据
+                ClearShow();
+                _slidingIdx[0] = -1;
+                _slidingIdx[1] = -1;
+                return;
+            }
+
+            // 计算viewport上边界往下会会显示的最小item的索引
+            if (_slidingPosition[0] <= padding.left)
+            {
+                _slidingIdx[0] = 0;
+            }
+            else
+            {
+                var idx = Mathf.FloorToInt((_slidingPosition[0] - padding.left) / (templateWidth + spacing));
+                var bottomPosition = padding.left + (idx + 1) * (templateWidth + spacing) - spacing;
+                if (bottomPosition > _slidingPosition[0])
+                    _slidingIdx[0] = idx;
+                else
+                    _slidingIdx[0] = idx + 1;
+            }
+
+            if (_slidingIdx[0] + 1 > _itemNum)
+            {
+                // 没有需要显示的数据
+                ClearShow();
+                _slidingIdx[0] = -1;
+                _slidingIdx[1] = -1;
+                return;
+            }
+
+            // 计算viewport下边界往下会会显示的最大item的索引
+            if (_slidingPosition[1] >= contentWidth - padding.right)
+            {
+                _slidingIdx[1] = _itemNum - 1;
+            }
+            else
+            {
+                // _slidingPosition[1] - padding.left 一定 大于 0
+                var idx = Mathf.FloorToInt((_slidingPosition[1] - padding.left) / (templateWidth + spacing));
+                _slidingIdx[1] = idx;
+            }
+
+            if (_slidingIdx[0] > _slidingIdx[1])
+            {
+                // 没有需要显示的数据
+                ClearShow();
+                _slidingIdx[0] = -1;
+                _slidingIdx[1] = -1;
+                return;
+            }
+
+            if (_showingItems.Count == 0) // 没有已展示的item
+            {
+                for (int i = _slidingIdx[0]; i <= _slidingIdx[1]; i++)
+                {
+                    var itemIdx = Rent();
+                    PlaceItem(itemIdx, i, childAlignment, padding);
+                    _showingItems.AddLast(itemIdx);
+                    OnScrollItemShow?.Invoke(i, itemIdx);
+                }
+            }
+            else
+            {
+                // 交集的部分处理
+                {
+                    var node = _showingItems.First;
+                    for (int i = _previousIdx[0]; i <= _previousIdx[1]; i++)
+                    {
+                        var itemIdx = node.Value;
+                        if (i >= _slidingIdx[0] && i <= _slidingIdx[1])
+                        {
+                            // 这里刷新元素位置和大小，是因为保证item元素大小的正常显示
+                            PlaceItem(itemIdx, i, childAlignment, padding);
+                            if (refreshAll)
+                                OnScrollItemShow?.Invoke(i, itemIdx);
+                        }
+
+                        node = node.Next;
+                        if (node == null)
+                            break;
+                    }
+                }
+
+                if (_slidingIdx[0] > _previousIdx[1] || _slidingIdx[1] < _previousIdx[0]) // 之前展示的元素和将展示的元素没有交集
+                {
+                    ClearShow();
+                    for (int i = _slidingIdx[0]; i <= _slidingIdx[1]; i++)
+                    {
+                        var itemIdx = Rent();
+                        PlaceItem(itemIdx, i, childAlignment, padding);
+                        _showingItems.AddLast(itemIdx);
+                        OnScrollItemShow?.Invoke(i, itemIdx);
+                    }
+                }
+                else // 之前展示的元素和将展示的元素有交集
+                {
+                    // 需要移除的前半部分
+                    if (_previousIdx[0] < _slidingIdx[0])
+                        for (int i = _previousIdx[0]; i < _slidingIdx[0]; i++)
+                        {
+                            var itemIdx = _showingItems.First.Value;
+                            Return(itemIdx);
+                            _showingItems.RemoveFirst();
+                            OnScrollItemHide?.Invoke(i, itemIdx);
+                        }
+
+                    // 需要移除的后半部分
+                    if (_previousIdx[1] > _slidingIdx[1])
+                        for (int i = _previousIdx[1]; i > _slidingIdx[1]; i--)
+                        {
+                            var itemIdx = _showingItems.Last.Value;
+                            Return(itemIdx);
+                            _showingItems.RemoveLast();
+                            OnScrollItemHide?.Invoke(i, itemIdx);
+                        }
+
+                    // 需要添加的前半部分
+                    if (_previousIdx[0] > _slidingIdx[0])
+                        for (int i = _previousIdx[0] - 1; i >= _slidingIdx[0]; i--)
+                        {
+                            var itemIdx = Rent();
+                            PlaceItem(itemIdx, i, childAlignment, padding);
+                            _showingItems.AddFirst(itemIdx);
+                            OnScrollItemShow?.Invoke(i, itemIdx);
+                        }
+
+                    // 需要添加的后半部分
+                    if (_previousIdx[1] < _slidingIdx[1])
+                        for (int i = _previousIdx[1] + 1; i <= _slidingIdx[1]; i++)
+                        {
+                            var itemIdx = Rent();
+                            PlaceItem(itemIdx, i, childAlignment, padding);
+                            _showingItems.AddLast(itemIdx);
+                            OnScrollItemShow?.Invoke(i, itemIdx);
+                        }
+                }
+            }
+        }
+
+        /// <summary>
+        /// 放置Item
+        /// </summary>
+        private void PlaceItem(int itemIdx, int idx, TextAnchor childAlignment, RectOffset padding)
+        {
+            var item = _items[itemIdx];
+            item.name = idx.ToString();
+            var itemRect = (RectTransform)item.transform;
+            var contentHeight = _contentRect.rect.height;
+            var childControlHeight = horizontalLayoutGroup.childControlHeight;
+            if (contentHeight == 0)
+            {
+                if (scrollRect.horizontalScrollbar)
+                    contentHeight = _scrollViewRect.rect.height - ((RectTransform)scrollRect.horizontalScrollbar.transform).rect.height;
+                else
+                    contentHeight = _scrollViewRect.rect.height;
+            }
+
+            switch (childAlignment)
+            {
+                case TextAnchor.UpperLeft or TextAnchor.UpperCenter or TextAnchor.UpperRight:
+                    itemRect.anchorMin = new Vector2(0, 1);
+                    itemRect.anchorMax = new Vector2(0, 1);
+                    itemRect.pivot = new Vector2(0, 1);
+                    itemRect.anchoredPosition = new Vector2(GetItemLocation(idx), -padding.top);
+                    break;
+                case TextAnchor.MiddleLeft or TextAnchor.MiddleCenter or TextAnchor.MiddleRight:
+                    itemRect.anchorMin = new Vector2(0, 0.5f);
+                    itemRect.anchorMax = new Vector2(0, 0.5f);
+                    itemRect.pivot = new Vector2(0, 0.5f);
+                    itemRect.anchoredPosition = new Vector2(GetItemLocation(idx), childControlHeight ? 0 : padding.bottom - padding.top);
+                    break;
+                case TextAnchor.LowerLeft or TextAnchor.LowerCenter or TextAnchor.LowerRight:
+                    itemRect.anchorMin = new Vector2(0, 0);
+                    itemRect.anchorMax = new Vector2(0, 0);
+                    itemRect.pivot = new Vector2(0, 0);
+                    itemRect.anchoredPosition = new Vector2(GetItemLocation(idx), padding.bottom);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            if (childControlHeight)
+                itemRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, contentHeight - padding.vertical);
+            else
+                itemRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, _itemTemplateRect.rect.height);
+        }
+
+        private float GetItemLocation(int idx)
+        {
+            if (idx < 0)
+                throw new Exception("idx can't less than 0");
+            var padding = horizontalLayoutGroup.padding;
+            var spacing = horizontalLayoutGroup.spacing;
+            return padding.top + idx * (_itemTemplateRect.rect.width + spacing);
+        }
+
+        private void ClearShow()
+        {
+            if (_showingItems.Count == 0)
+                return;
+            for (int i = _previousIdx[0]; i <= _previousIdx[1]; i++)
+            {
+                var itemIdx = _showingItems.First.Value;
+                Return(itemIdx);
+                _showingItems.RemoveFirst();
+                OnScrollItemHide?.Invoke(i, itemIdx);
+            }
+        }
+
+        public void SetItemNum(int itemNum)
+        {
+            if (itemNum <= 0)
+            {
+                _itemNum = 0;
+                _contentRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 0);
+                return;
+            }
+
+            _itemNum = itemNum;
+            var padding = horizontalLayoutGroup.padding;
+            var spacing = horizontalLayoutGroup.spacing;
+            // 计算并设置好content的大小
+            _contentRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, padding.left + padding.right + _itemTemplateRect.sizeDelta.x * itemNum + spacing * Mathf.Max(0, itemNum - 1));
+        }
+
+
+        #region Pool
+
+        private int Rent()
+        {
+            GameObject item;
+            if (!_pools.TryDequeue(out var itemIdx))
+            {
+                item = Instantiate(itemTemplate.gameObject, _contentRect);
+                _items.Add(item);
+                itemIdx = _items.Count - 1;
+                OnScrollItemCreate?.Invoke(item, itemIdx);
+            }
+            else
+            {
+                item = _items[itemIdx];
+            }
+
+            item.SetActive(true);
+            return itemIdx;
+        }
+
+        private void Return(int itemIdx)
+        {
+            var item = _items[itemIdx];
+            item.name = "poolItem";
+            item.SetActive(false);
+            _pools.Enqueue(itemIdx);
+        }
+
+        #endregion
+
+
+        #region 移动
+
+        public void MoveToBegin(float duration, Action onCompleted = null) => MoveToContentPos(0, duration, onCompleted);
+
+        public void MoveToEnd(float duration, Action onCompleted = null)
+        {
+            float viewportWidth = _viewportRect.rect.width;
+            if (viewportWidth == 0)
+                viewportWidth = _scrollViewRect.rect.width;
+            MoveToContentPos(_contentRect.rect.width - viewportWidth, duration, onCompleted);
+        }
+
+        public void MoveToIdx(int idx, float duration, Action onCompleted = null)
+        {
+            if (_itemNum <= 0 || idx < 0 || idx + 1 > _itemNum)
+            {
+                Log.Warning($"不可移动到指定索引 {idx}");
+                return;
+            }
+
+            if (idx > _slidingIdx[0] && idx < _slidingIdx[1])
+            {
+                scrollRect.StopMovement();
+                onCompleted?.Invoke();
+                return;
+            }
+
+            var targetLocation = GetItemLocation(idx);
+            var targetBottomLocation = targetLocation + _itemTemplateRect.rect.height;
+            if (idx == _slidingIdx[0])
+            {
+                if (targetLocation > _slidingPosition[0] && targetBottomLocation < _slidingPosition[1])
+                {
+                    scrollRect.StopMovement();
+                    onCompleted?.Invoke();
+                }
+                else
+                {
+                    MoveToContentPos(targetLocation + 0.01f, duration, onCompleted);
+                }
+
+                return;
+            }
+
+            if (idx < _slidingIdx[0])
+            {
+                MoveToContentPos(targetLocation + 0.01f, duration, onCompleted);
+                return;
+            }
+
+            float viewportWidth = _viewportRect.rect.width;
+            if (viewportWidth == 0)
+                viewportWidth = _scrollViewRect.rect.width;
+            if (idx == _slidingIdx[1])
+            {
+                if (targetLocation > _slidingPosition[0] && targetBottomLocation < _slidingPosition[1])
+                {
+                    scrollRect.StopMovement();
+                    onCompleted?.Invoke();
+                }
+                else
+                {
+                    MoveToContentPos(targetBottomLocation - viewportWidth - 0.01f, duration, onCompleted);
+                }
+
+                return;
+            }
+
+            if (idx > _slidingIdx[0])
+            {
+                MoveToContentPos(targetBottomLocation - viewportWidth - 0.01f, duration, onCompleted);
+            }
+        }
+
+        public void MoveToContentPos(float pos, float duration, Action onCompleted = null)
+        {
+            var elasticity = scrollRect.elasticity;
+            scrollRect.elasticity = 0;
+            var movementType = scrollRect.movementType;
+            scrollRect.movementType = ScrollRect.MovementType.Clamped;
+            _contentRect.DOLocalMoveX(-pos, duration).OnComplete(() =>
+            {
+                scrollRect.StopMovement();
+                scrollRect.movementType = movementType;
+                scrollRect.elasticity = elasticity;
+                onCompleted?.Invoke();
+            });
+        }
+
+        #endregion
+
+        /// <summary>
+        /// 刷新数据
+        /// </summary>
+        public void Refresh()
+        {
+            RefreshViewport(true);
+        }
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/FantasyScrollView/FantasyScrollViewComponent.cs
+++ b/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/FantasyScrollView/FantasyScrollViewComponent.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+namespace Fantasy
+{
+    public class FantasyScrollViewComponent<TItem, TData> : Entity, IFantasyScrollViewComponent where TItem : SubUI, IScrollItem<TData>, new()
+    {
+        public IFantasyScrollView scroll;
+        public readonly List<TItem> items = new();
+        public List<TData> data;
+
+        public void Initialize(IFantasyScrollView scrollView)
+        {
+            scroll = scrollView;
+            scrollView.OnScrollItemShow = OnScrollItemShow;
+            scrollView.OnScrollItemCreate = OnScrollItemCreate;
+            scrollView.OnScrollItemHide = OnScrollItemHide;
+        }
+
+        public void SetData(List<TData> dataList)
+        {
+            data = dataList;
+            scroll.SetItemNum(data.Count);
+            scroll.Refresh();
+        }
+
+        public void Refresh() => scroll.Refresh();
+
+        private void OnScrollItemHide(int idx, int itemIdx)
+        {
+            if (idx < data.Count)
+                items[itemIdx].OnHide(idx);
+        }
+
+        private void OnScrollItemCreate(GameObject gameObject, int itemIdx)
+        {
+            var ui = Create<TItem>(Scene);
+            ui.GameObject = gameObject;
+            ui.Initialize();
+            ui.OnCreate(scroll);
+            EntitiesSystem.Instance.Awake(ui);
+            EntitiesSystem.Instance.StartUpdate(ui);
+            items.Add(ui);
+        }
+
+        private void OnScrollItemShow(int idx, int itemIdx)
+        {
+            if (idx < data.Count)
+                items[itemIdx].OnShowOrRefresh(idx, data[idx]);
+        }
+
+        public FTask MoveToBegin(float duration)
+        {
+            var tcs = FTask.Create();
+            scroll.MoveToBegin(duration, () => tcs.SetResult());
+            return tcs;
+        }
+
+        public FTask MoveToEnd(float duration)
+        {
+            var tcs = FTask.Create();
+            scroll.MoveToEnd(duration, () => tcs.SetResult());
+            return tcs;
+        }
+
+        public FTask MoveToIdx(int idx, float duration)
+        {
+            var tcs = FTask.Create();
+            scroll.MoveToIdx(idx, duration, () => tcs.SetResult());
+            return tcs;
+        }
+
+        public override void Dispose()
+        {
+            items.Clear();
+            base.Dispose();
+        }
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/FantasyScrollView/FantasyVerticalScrollView.cs
+++ b/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/FantasyScrollView/FantasyVerticalScrollView.cs
@@ -1,0 +1,455 @@
+﻿using System;
+using System.Collections.Generic;
+using DG.Tweening;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Fantasy
+{
+    /// <summary>
+    /// 循环复用滑动列表（竖直滑动）
+    /// </summary>
+    [DisallowMultipleComponent]
+    public class FantasyVerticalScrollView : MonoBehaviour, IFantasyScrollView
+    {
+        public ScrollRect scrollRect;
+        public FantasyRef itemTemplate;
+        public VerticalLayoutGroup verticalLayoutGroup;
+        public ContentSizeFitter contentSizeFitter;
+
+        private RectTransform _contentRect;
+        private RectTransform _itemTemplateRect;
+        private RectTransform _viewportRect;
+        private RectTransform _scrollViewRect;
+
+        private readonly float[] _slidingPosition = new float[2];
+        private readonly int[] _slidingIdx = { -1, -1 };
+        private readonly int[] _previousIdx = { -1, -1 };
+        private readonly LinkedList<int> _showingItems = new();
+        private readonly Queue<int> _pools = new();
+        private readonly List<GameObject> _items = new();
+
+        public OnScrollItemShow OnScrollItemShow { get; set; }
+        public OnScrollItemCreate OnScrollItemCreate { get; set; }
+        public OnScrollItemHide OnScrollItemHide { get; set; }
+
+        private int _itemNum;
+
+        private void Awake()
+        {
+            if (contentSizeFitter)
+                contentSizeFitter.enabled = false;
+            verticalLayoutGroup.enabled = false;
+
+            itemTemplate.gameObject.SetActive(false);
+            _scrollViewRect = scrollRect.transform as RectTransform;
+            _contentRect = scrollRect.content;
+            _viewportRect = scrollRect.viewport;
+            _itemTemplateRect = itemTemplate.transform as RectTransform;
+            scrollRect.vertical = true;
+            scrollRect.horizontal = false;
+            _contentRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 0);
+            scrollRect.onValueChanged.AddListener(_ => RefreshViewport());
+#if UNITY_EDITOR
+            // 这里是为了让LayoutGroup在运行中发生更改时，能够实时反应到表现上
+            if (!verticalLayoutGroup)
+                return;
+            _layoutGroupInstanceId = verticalLayoutGroup.GetInstanceID(); // 保证Destroy时能够正确找到对应的instanceId
+            FantasyEditorEventHelper.AddListener(_layoutGroupInstanceId, () =>
+            {
+                SetItemNum(_itemNum);
+                Refresh();
+            });
+#endif
+        }
+
+#if UNITY_EDITOR
+        private int _layoutGroupInstanceId;
+        private void OnDestroy()
+        {
+            FantasyEditorEventHelper.RemoveAllListener(_layoutGroupInstanceId);
+        }
+#endif
+        private void RefreshViewport(bool refreshAll = false)
+        {
+            // 计算当前content中显示的区域范围
+            float viewportHeight = _viewportRect.rect.height;
+            if (viewportHeight == 0)
+                viewportHeight = _scrollViewRect.rect.height;
+            float contentHeight = _contentRect.rect.height;
+            _slidingPosition[0] = Mathf.Max(0, _contentRect.anchoredPosition.y);
+            _slidingPosition[1] = Mathf.Min(contentHeight, _contentRect.anchoredPosition.y + viewportHeight);
+
+            // 计算需要显示的数据索引
+            var padding = verticalLayoutGroup.padding;
+            var spacing = verticalLayoutGroup.spacing;
+            var childAlignment = verticalLayoutGroup.childAlignment;
+            var templateHeight = _itemTemplateRect.rect.height;
+
+            // 记录上一次展示的item
+            _previousIdx[0] = _slidingIdx[0];
+            _previousIdx[1] = _slidingIdx[1];
+            if (_slidingPosition[1] <= _slidingPosition[0])
+            {
+                // 没有需要显示的数据
+                ClearShow();
+                _slidingIdx[0] = -1;
+                _slidingIdx[1] = -1;
+                return;
+            }
+
+            // 计算viewport上边界往下会会显示的最小item的索引
+            if (_slidingPosition[0] <= padding.top)
+            {
+                _slidingIdx[0] = 0;
+            }
+            else
+            {
+                var idx = Mathf.FloorToInt((_slidingPosition[0] - padding.top) / (templateHeight + spacing));
+                var bottomPosition = padding.top + (idx + 1) * (templateHeight + spacing) - spacing;
+                if (bottomPosition > _slidingPosition[0])
+                    _slidingIdx[0] = idx;
+                else
+                    _slidingIdx[0] = idx + 1;
+            }
+
+            if (_slidingIdx[0] + 1 > _itemNum)
+            {
+                // 没有需要显示的数据
+                ClearShow();
+                _slidingIdx[0] = -1;
+                _slidingIdx[1] = -1;
+                return;
+            }
+
+            // 计算viewport下边界往下会会显示的最大item的索引
+            if (_slidingPosition[1] >= contentHeight - padding.bottom)
+            {
+                _slidingIdx[1] = _itemNum - 1;
+            }
+            else
+            {
+                // _slidingPosition[1] - padding.top 一定 大于 0
+                var idx = Mathf.FloorToInt((_slidingPosition[1] - padding.top) / (templateHeight + spacing));
+                _slidingIdx[1] = idx;
+            }
+
+            if (_slidingIdx[0] > _slidingIdx[1])
+            {
+                // 没有需要显示的数据
+                ClearShow();
+                _slidingIdx[0] = -1;
+                _slidingIdx[1] = -1;
+                return;
+            }
+
+            if (_showingItems.Count == 0) // 没有已展示的item
+            {
+                for (int i = _slidingIdx[0]; i <= _slidingIdx[1]; i++)
+                {
+                    var itemIdx = Rent();
+                    PlaceItem(itemIdx, i, childAlignment, padding);
+                    _showingItems.AddLast(itemIdx);
+                    OnScrollItemShow?.Invoke(i, itemIdx);
+                }
+            }
+            else
+            {
+                if (_slidingIdx[0] > _previousIdx[1] || _slidingIdx[1] < _previousIdx[0]) // 之前展示的元素和将展示的元素没有交集
+                {
+                    ClearShow();
+                    for (int i = _slidingIdx[0]; i <= _slidingIdx[1]; i++)
+                    {
+                        var itemIdx = Rent();
+                        PlaceItem(itemIdx, i, childAlignment, padding);
+                        _showingItems.AddLast(itemIdx);
+                        OnScrollItemShow?.Invoke(i, itemIdx);
+                    }
+                }
+                else // 之前展示的元素和将展示的元素有交集
+                {
+                    // 交集的部分处理
+                    {
+                        var node = _showingItems.First;
+                        for (int i = _previousIdx[0]; i <= _previousIdx[1]; i++)
+                        {
+                            var itemIdx = node.Value;
+                            if (i >= _slidingIdx[0] && i <= _slidingIdx[1])
+                            {
+                                // 这里刷新元素位置和大小，是因为保证item元素大小的正常显示
+                                PlaceItem(itemIdx, i, childAlignment, padding);
+                                if (refreshAll)
+                                    OnScrollItemShow?.Invoke(i, itemIdx);
+                            }
+
+                            node = node.Next;
+                            if (node == null)
+                                break;
+                        }
+                    }
+
+                    // 需要移除的前半部分
+                    if (_previousIdx[0] < _slidingIdx[0])
+                        for (int i = _previousIdx[0]; i < _slidingIdx[0]; i++)
+                        {
+                            var itemIdx = _showingItems.First.Value;
+                            Return(itemIdx);
+                            _showingItems.RemoveFirst();
+                            OnScrollItemHide?.Invoke(i, itemIdx);
+                        }
+
+                    // 需要移除的后半部分
+                    if (_previousIdx[1] > _slidingIdx[1])
+                        for (int i = _previousIdx[1]; i > _slidingIdx[1]; i--)
+                        {
+                            var itemIdx = _showingItems.Last.Value;
+                            Return(itemIdx);
+                            _showingItems.RemoveLast();
+                            OnScrollItemHide?.Invoke(i, itemIdx);
+                        }
+
+                    // 需要添加的前半部分
+                    if (_previousIdx[0] > _slidingIdx[0])
+                        for (int i = _previousIdx[0] - 1; i >= _slidingIdx[0]; i--)
+                        {
+                            var itemIdx = Rent();
+                            PlaceItem(itemIdx, i, childAlignment, padding);
+                            _showingItems.AddFirst(itemIdx);
+                            OnScrollItemShow?.Invoke(i, itemIdx);
+                        }
+
+                    // 需要添加的后半部分
+                    if (_previousIdx[1] < _slidingIdx[1])
+                        for (int i = _previousIdx[1] + 1; i <= _slidingIdx[1]; i++)
+                        {
+                            var itemIdx = Rent();
+                            PlaceItem(itemIdx, i, childAlignment, padding);
+                            _showingItems.AddLast(itemIdx);
+                            OnScrollItemShow?.Invoke(i, itemIdx);
+                        }
+                }
+            }
+        }
+
+        /// <summary>
+        /// 放置Item
+        /// </summary>
+        private void PlaceItem(int itemIdx, int idx, TextAnchor childAlignment, RectOffset padding)
+        {
+            var item = _items[itemIdx];
+            item.name = idx.ToString();
+            var itemRect = (RectTransform)item.transform;
+            var contentWidth = _contentRect.rect.width;
+            var childControlWidth = verticalLayoutGroup.childControlWidth;
+            if (contentWidth == 0)
+            {
+                if (scrollRect.verticalScrollbar)
+                    contentWidth = _scrollViewRect.rect.width - ((RectTransform)scrollRect.verticalScrollbar.transform).rect.width;
+                else
+                    contentWidth = _scrollViewRect.rect.width;
+            }
+
+            switch (childAlignment)
+            {
+                case TextAnchor.UpperLeft or TextAnchor.MiddleLeft or TextAnchor.LowerLeft:
+                    // 左上角
+                    itemRect.anchorMin = new Vector2(0, 1);
+                    itemRect.anchorMax = new Vector2(0, 1);
+                    itemRect.pivot = new Vector2(0, 1);
+                    itemRect.anchoredPosition = new Vector2(padding.left, -GetItemLocation(idx));
+                    break;
+                case TextAnchor.UpperCenter or TextAnchor.LowerCenter or TextAnchor.MiddleCenter:
+                    // 上中
+                    itemRect.anchorMin = new Vector2(0.5f, 1);
+                    itemRect.anchorMax = new Vector2(0.5f, 1);
+                    itemRect.pivot = new Vector2(0.5f, 1);
+                    itemRect.anchoredPosition = new Vector2(childControlWidth ? 0 : padding.left - padding.right, -GetItemLocation(idx));
+                    break;
+                case TextAnchor.UpperRight or TextAnchor.MiddleRight or TextAnchor.LowerRight:
+                    // 右上角
+                    itemRect.anchorMin = new Vector2(1, 1);
+                    itemRect.anchorMax = new Vector2(1, 1);
+                    itemRect.pivot = new Vector2(1, 1);
+                    itemRect.anchoredPosition = new Vector2(-padding.right, -GetItemLocation(idx));
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            if (childControlWidth)
+                itemRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, contentWidth - padding.horizontal);
+            else
+                itemRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, _itemTemplateRect.rect.width);
+        }
+
+        private float GetItemLocation(int idx)
+        {
+            if (idx < 0)
+                throw new Exception("idx can't less than 0");
+            var padding = verticalLayoutGroup.padding;
+            var spacing = verticalLayoutGroup.spacing;
+            return padding.top + idx * (_itemTemplateRect.rect.height + spacing);
+        }
+
+        private void ClearShow()
+        {
+            if (_showingItems.Count == 0)
+                return;
+            for (int i = _previousIdx[0]; i <= _previousIdx[1]; i++)
+            {
+                var itemIdx = _showingItems.First.Value;
+                Return(itemIdx);
+                _showingItems.RemoveFirst();
+                OnScrollItemHide?.Invoke(i, itemIdx);
+            }
+        }
+
+        public void SetItemNum(int itemNum)
+        {
+            if (itemNum <= 0)
+            {
+                _itemNum = 0;
+                _contentRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 0);
+                return;
+            }
+
+            _itemNum = itemNum;
+            var padding = verticalLayoutGroup.padding;
+            var spacing = verticalLayoutGroup.spacing;
+            // 计算并设置好content的大小
+            _contentRect.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, padding.top + padding.bottom + _itemTemplateRect.sizeDelta.y * itemNum + spacing * Mathf.Max(0, itemNum - 1));
+        }
+
+
+        #region Pool
+
+        private int Rent()
+        {
+            GameObject item;
+            if (!_pools.TryDequeue(out var itemIdx))
+            {
+                item = Instantiate(itemTemplate.gameObject, _contentRect);
+                _items.Add(item);
+                itemIdx = _items.Count - 1;
+                OnScrollItemCreate?.Invoke(item, itemIdx);
+            }
+            else
+            {
+                item = _items[itemIdx];
+            }
+
+            item.SetActive(true);
+            return itemIdx;
+        }
+
+        private void Return(int itemIdx)
+        {
+            var item = _items[itemIdx];
+            item.name = "poolItem";
+            item.SetActive(false);
+            _pools.Enqueue(itemIdx);
+        }
+
+        #endregion
+
+
+        #region 移动
+
+        public void MoveToBegin(float duration, Action onCompleted = null) => MoveToContentPos(0, duration, onCompleted);
+
+        public void MoveToEnd(float duration, Action onCompleted = null)
+        {
+            float viewportHeight = _viewportRect.rect.height;
+            if (viewportHeight == 0)
+                viewportHeight = _scrollViewRect.rect.height;
+            MoveToContentPos(_contentRect.rect.height - viewportHeight, duration, onCompleted);
+        }
+
+        public void MoveToIdx(int idx, float duration, Action onCompleted = null)
+        {
+            if (_itemNum <= 0 || idx < 0 || idx + 1 > _itemNum)
+            {
+                Log.Warning($"不可移动到指定索引 {idx}");
+                return;
+            }
+
+            if (idx > _slidingIdx[0] && idx < _slidingIdx[1])
+            {
+                scrollRect.StopMovement();
+                onCompleted?.Invoke();
+                return;
+            }
+
+            var targetLocation = GetItemLocation(idx);
+            var targetBottomLocation = targetLocation + _itemTemplateRect.rect.height;
+            if (idx == _slidingIdx[0])
+            {
+                if (targetLocation > _slidingPosition[0] && targetBottomLocation < _slidingPosition[1])
+                {
+                    scrollRect.StopMovement();
+                    onCompleted?.Invoke();
+                }
+                else
+                {
+                    MoveToContentPos(targetLocation + 0.01f, duration, onCompleted);
+                }
+
+                return;
+            }
+
+            if (idx < _slidingIdx[0])
+            {
+                MoveToContentPos(targetLocation + 0.01f, duration, onCompleted);
+                return;
+            }
+
+            float viewportHeight = _viewportRect.rect.height;
+            if (viewportHeight == 0)
+                viewportHeight = _scrollViewRect.rect.height;
+            if (idx == _slidingIdx[1])
+            {
+                if (targetLocation > _slidingPosition[0] && targetBottomLocation < _slidingPosition[1])
+                {
+                    scrollRect.StopMovement();
+                    onCompleted?.Invoke();
+                }
+                else
+                {
+                    MoveToContentPos(targetBottomLocation - viewportHeight - 0.01f, duration, onCompleted);
+                }
+
+                return;
+            }
+
+            if (idx > _slidingIdx[0])
+            {
+                MoveToContentPos(targetBottomLocation - viewportHeight - 0.01f, duration, onCompleted);
+            }
+        }
+
+        public void MoveToContentPos(float pos, float duration, Action onCompleted = null)
+        {
+            var elasticity = scrollRect.elasticity;
+            scrollRect.elasticity = 0;
+            var movementType = scrollRect.movementType;
+            scrollRect.movementType = ScrollRect.MovementType.Clamped;
+            _contentRect.DOLocalMoveY(pos, duration).OnComplete(() =>
+            {
+                scrollRect.StopMovement();
+                scrollRect.movementType = movementType;
+                scrollRect.elasticity = elasticity;
+                onCompleted?.Invoke();
+            });
+        }
+
+        #endregion
+
+        /// <summary>
+        /// 刷新数据
+        /// </summary>
+        public void Refresh()
+        {
+            RefreshViewport(true);
+        }
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/FantasyScrollView/IFantasyScrollView.cs
+++ b/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/FantasyScrollView/IFantasyScrollView.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using UnityEngine;
+
+namespace Fantasy
+{
+    public delegate void OnScrollItemShow(int idx, int itemIdx);
+
+    public delegate void OnScrollItemHide(int idx, int itemIdx);
+
+    public delegate void OnScrollItemCreate(GameObject gameObject, int itemIdx);
+
+    public interface IFantasyScrollView
+    {
+        void MoveToBegin(float duration, Action onCompleted = null);
+        void MoveToEnd(float duration, Action onCompleted = null);
+        void MoveToIdx(int idx, float duration, Action onCompleted = null);
+
+        void SetItemNum(int itemNum);
+        void Refresh();
+
+        OnScrollItemShow OnScrollItemShow { get; set; }
+        OnScrollItemCreate OnScrollItemCreate { get; set; }
+        OnScrollItemHide OnScrollItemHide { get; set; }
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/FantasyScrollView/IFantasyScrollViewComponent.cs
+++ b/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/FantasyScrollView/IFantasyScrollViewComponent.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Fantasy
+{
+    public interface IFantasyScrollViewComponent : IDisposable
+    {
+        void Refresh();
+        FTask MoveToBegin(float duration);
+        FTask MoveToEnd(float duration);
+        FTask MoveToIdx(int idx, float duration);
+    }
+}

--- a/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/FantasyScrollView/IScrollItem.cs
+++ b/Packages.Unity/Fantasy.Unity/Runtime/Fantasy.App/UI/FantasyScrollView/IScrollItem.cs
@@ -1,0 +1,9 @@
+﻿namespace Fantasy
+{
+    public interface IScrollItem<in T>
+    {
+        void OnCreate(IFantasyScrollView scrollView);
+        void OnShowOrRefresh(int idx, T data);
+        void OnHide(int idx);
+    }
+}


### PR DESCRIPTION
# 新增功能
1. 新增 EditorIcons窗口，可以通过 Tools/Editor Icons 或者快捷键 Ctrl + E 唤出
2. 新增 2个用于获取游戏物体引用的Unity组件，FantasyRef、FantasyUIRef。通过它们可以生成Fantasy的脚本。
3. 新增SubUI脚本。
4. 新增 3个复用列表组件，FantasyGridScrollView、FantasyVerticalScrollView、FantasyHorizontalScrollView。
5. 新增在Hierarchy窗口快速绑定组件引用和移除组件引用的功能。
6. 在FantasySettings面板新增快速引用功能的开关，以及编辑引用规则的功能