### PR TITLE
[优化]Http服务返回数据变小写的问题修复

### DIFF
--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Network/Protocol/HTTP/HTTPServerNetwork.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Network/Protocol/HTTP/HTTPServerNetwork.cs
@@ -58,7 +58,8 @@ namespace Fantasy.Network.HTTP
             // 注册Scene同步过滤器
             builder.Services.AddScoped<SceneContextFilter>();
             // 注册控制器服务
-            var addControllers = builder.Services.AddControllers();
+            var addControllers = builder.Services.AddControllers()
+                .AddJsonOptions(options => { options.JsonSerializerOptions.PropertyNamingPolicy = null; });
             foreach (var assembly in AssemblySystem.ForEachAssembly)
             {
                 addControllers.AddApplicationPart(assembly);


### PR DESCRIPTION
step1:定义如下请求和返回
public class GetUserIdRequest
{
    public string OpenId { get; set; }
}

public class GetUserIdResponse
{
    public int ErrorCode { get; set; }
    public long UserId { get; set; }
}

step2:
返回的是：
{
   errorCode: 0,
  userId: 12121
}

step3: 做出上述修改后，返回了期望的数据格式：
{
   ErrorCode: 0,
   UserId: 12121
}

