### PR TITLE
perf：优化日志重定向，支持mac系统，并且支持跳到捕获到的异常调用栈中的正确文件

### DIFF
--- a/Fantasy.Unity/Fantasy.Unity/Runtime/Core/Log/UnityLog.cs
+++ b/Fantasy.Unity/Fantasy.Unity/Runtime/Core/Log/UnityLog.cs
@@ -71,3 +71,162 @@ namespace Fantasy
     }
 }
 #endif
+
+#if UNITY_EDITOR
+namespace Fantasy
+{
+    /// <summary>
+    /// 日志重定向相关的实用函数。
+    /// </summary>
+    internal static class LogRedirection
+    {
+        [OnOpenAsset(0)]
+        private static bool OnOpenAsset(int instanceID, int line)
+        {
+            if (line <= 0)
+            {
+                return false;
+            }
+
+            // 获取资源路径
+            string assetPath = AssetDatabase.GetAssetPath(instanceID);
+
+            // 判断资源类型
+            if (!assetPath.EndsWith(".cs"))
+            {
+                return false;
+            }
+
+            bool autoFirstMatch = assetPath.Contains("Log.cs") ||
+                                   assetPath.Contains("UnityLog.cs");
+
+            var stackTrace = GetStackTrace();
+            if (!string.IsNullOrEmpty(stackTrace))
+
+            {
+                if (!autoFirstMatch)
+                {
+                    var fullPath = UnityEngine.Application.dataPath.Substring(0, UnityEngine.Application.dataPath.LastIndexOf("Assets", StringComparison.Ordinal));
+                    fullPath = $"{fullPath}{assetPath}";
+                    // 跳转到目标代码的特定行
+                    if (UnityEngine.RuntimePlatform.WindowsEditor == UnityEngine.Application.platform)
+                    {
+                        fullPath = fullPath.Replace('/', '\\');
+                    }
+                    InternalEditorUtility.OpenFileAtLineExternal(fullPath, line);
+                    return true;
+                }
+                
+                // 先尝试匹配异常堆栈中的确切文件路径（格式为：[0x0000d] in /路径/文件.cs:行号）
+                var exceptionMatches = Regex.Matches(stackTrace, @"\[\w+\]\s+in\s+([^\s]+):(\d+)", RegexOptions.Multiline);
+                
+                // 存储所有匹配的文件和行号
+                var validPaths = new List<(string path, int line)>();
+                
+                // 优先处理异常堆栈中的路径信息
+                if (exceptionMatches.Count > 0)
+                {
+                    for (int i = 0; i < exceptionMatches.Count; i++)
+                    {
+                        if (exceptionMatches[i].Groups.Count >= 3)
+                        {
+                            string fullPath = exceptionMatches[i].Groups[1].Value;
+                            int fileLine = int.Parse(exceptionMatches[i].Groups[2].Value);
+                            
+                            // 获取Assets开始的相对路径
+                            int assetsIndex = fullPath.IndexOf("Assets");
+                            if (assetsIndex >= 0)
+                            {
+                                string relativePath = fullPath.Substring(assetsIndex);
+                                validPaths.Add((relativePath, fileLine));
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    // 如果没有匹配到异常格式，则使用旧的(at ...)格式
+                    // 使用正则表达式匹配at的哪个脚本的哪一行
+                    var matches = Regex.Match(stackTrace, @"\(at (.+)\)",
+                        RegexOptions.IgnoreCase);
+
+                    while (matches.Success)
+                    {
+                        var pathLine = matches.Groups[1].Value;
+    
+                        if (!pathLine.Contains("Log.cs") &&
+                            !pathLine.Contains("UnityLog.cs"))
+                        {
+                            var splitIndex = pathLine.LastIndexOf(":", StringComparison.Ordinal);
+                            // 脚本路径
+                            var path = pathLine.Substring(0, splitIndex);
+                            // 行号
+                            int fileLine = Convert.ToInt32(pathLine.Substring(splitIndex + 1));
+                            
+                            // 添加到有效路径列表
+                            validPaths.Add((path, fileLine));
+                        }
+    
+                        matches = matches.NextMatch();
+                    }
+                }
+                
+                // 如果找到有效的路径
+                if (validPaths.Count > 0)
+                {
+                    // 获取堆栈顶部的文件路径和行号（列表的第一个元素通常是堆栈顶部）
+                    string path = validPaths[0].path;
+                    int fileLine = validPaths[0].line;
+                    
+                    var fullPath = UnityEngine.Application.dataPath.Substring(0, UnityEngine.Application.dataPath.LastIndexOf("Assets", StringComparison.Ordinal));
+                    fullPath = $"{fullPath}{path}";
+                    // 跳转到目标代码的特定行
+                    if (UnityEngine.RuntimePlatform.WindowsEditor == UnityEngine.Application.platform)
+                    {
+                        fullPath = fullPath.Replace('/', '\\');
+                    }
+                    InternalEditorUtility.OpenFileAtLineExternal(fullPath, fileLine);
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// 获取当前日志窗口选中的日志的堆栈信息。
+        /// </summary>
+        /// <returns>选中日志的堆栈信息实例。</returns>
+        private static string GetStackTrace()
+        {
+            // 通过反射获取ConsoleWindow类
+            var consoleWindowType = typeof(EditorWindow).Assembly.GetType("UnityEditor.ConsoleWindow");
+            // 获取窗口实例
+            var fieldInfo = consoleWindowType.GetField("ms_ConsoleWindow",
+                BindingFlags.Static |
+                BindingFlags.NonPublic);
+            if (fieldInfo != null)
+            {
+                var consoleInstance = fieldInfo.GetValue(null);
+                if (consoleInstance != null)
+                    if (EditorWindow.focusedWindow == (EditorWindow)consoleInstance)
+                    {
+                        // 获取m_ActiveText成员
+                        fieldInfo = consoleWindowType.GetField("m_ActiveText",
+                            BindingFlags.Instance |
+                            BindingFlags.NonPublic);
+                        // 获取m_ActiveText的值
+                        if (fieldInfo != null)
+                        {
+                            var activeText = fieldInfo.GetValue(consoleInstance).ToString();
+                            return activeText;
+                        }
+                    }
+            }
+
+            return null;
+        }
+    }
+}
+#endif


### PR DESCRIPTION
之前删掉这段是因为会影响Mac在非UnityLog捕捉到的调用栈下的跳转，以及UnityLog捕捉到的也无法正确跳转，将其修改为正确的结果。例如：
System.NullReferenceException: Object reference not set to an instance of an object
  at Battle.UnitFactory.CreatePlayer (Battle.Room room, Battle.BattlePlayerData data) [0x0000d] in ${MyProject}/Assets/Scripts/Logic/Battle/Unit/UnitFactory.cs:23 
  at Battle.Room.Prepare (Battle.BattleEnterData data) [0x00020] in ${MyProject}/Assets/Scripts/Logic/Battle/Core/Room.cs:73 
  at Battle.Room.Enter (Battle.BattleEnterData data) [0x00046] in ${MyProject}/Assets/Scripts/Logic/Battle/Core/Room.cs:47 
  at BattleRoot.StartGame (Battle.BattleEnterData data) [0x00056] in ${MyProject}/Assets/Scripts/Views/Battle/Core/BattleRoot.cs:32 
  at System.Runtime.CompilerServices.AsyncMethodBuilderCore+<>c.<ThrowAsync>b__7_0 (System.Object state) [0x00000] in <a9c3ded09dcb4b3ea021286a5a859400>:0 
  at Fantasy.ThreadSynchronizationContext+<>c__DisplayClass3_0.<Post>b__0 () [0x00000] in ${MyProject}/Assets/Plugins/Fantasy.Unity/Runtime/Core/Platform/Unity/ThreadSynchronizationContext.cs:33 
  at Fantasy.ThreadSynchronizationContext.Update () [0x00005] in ${MyProject}/Assets/Plugins/Fantasy.Unity/Runtime/Core/Platform/Unity/ThreadSynchronizationContext.cs:22 
UnityEngine.Debug:LogError (object)
Fantasy.UnityLog:Error (string) (at Assets/Plugins/Fantasy.Unity/Runtime/Core/Log/UnityLog.cs:39)
Fantasy.Log:Error (System.Exception) (at Assets/Plugins/Fantasy.Unity/Runtime/Core/Log/Log.cs:133)
Fantasy.ThreadSynchronizationContext:Update () (at Assets/Plugins/Fantasy.Unity/Runtime/Core/Platform/Unity/ThreadSynchronizationContext.cs:26)
Fantasy.MainScheduler:Update () (at Assets/Plugins/Fantasy.Unity/Runtime/Core/Scene/Scheduler/MainScheduler.cs:63)
Fantasy.ThreadScheduler:Update () (at Assets/Plugins/Fantasy.Unity/Runtime/Core/Scene/Scheduler/ThreadScheduler.cs:30)
Fantasy.Platform.Unity.Entry:Update () (at Assets/Plugins/Fantasy.Unity/Runtime/Core/Platform/Unity/Entry.cs:85)
这一段，报错，如果没有重定向，将会打开UnityLog.cs:39，现在可以正确的跳转到UnitFactory.cs:23。
已经在Mac端测试过，因为没有Window环境，暂未测试。
Window端保留了之前会影响Mac端的fullPath.Replace('/', '\\');的代码，应该是OK的。