### PR TITLE
修复Console和Benchmark中的几处警告和错误

### DIFF
--- a/Fantasy.Benchmark/NetworkBenchmark.cs
+++ b/Fantasy.Benchmark/NetworkBenchmark.cs
@@ -21,7 +21,7 @@ public class NetworkBenchmark
         // 注册日志实例到框架中
         Log.Register(new ConsoleLog());
         // 初始化框架
-        Entry.Initialize();
+        await Entry.Initialize();
         // 执行StartUpdate方法
         Entry.StartUpdate();
         _scene = await Entry.CreateScene();

--- a/Fantays.Console/Runtime/Core/Helper/ByteHelper.cs
+++ b/Fantays.Console/Runtime/Core/Helper/ByteHelper.cs
@@ -21,9 +21,10 @@ namespace Fantasy.Helper
         public static long ReadInt64(FileStream stream)
         {
             var buffer = new byte[8];
-#if FANTASY_NET
+#if FANTASY_NET || FANTASY_CONSOLE
             stream.ReadExactly(buffer, 0, 8);
 #else
+            // CA2022 violation.
             stream.Read(buffer, 0, 8);
 #endif
             return BitConverter.ToInt64(buffer, 0);
@@ -35,9 +36,10 @@ namespace Fantasy.Helper
         public static int ReadInt32(FileStream stream)
         {
             var buffer = new byte[4];
-#if FANTASY_NET
+#if FANTASY_NET || FANTASY_CONSOLE
             stream.ReadExactly(buffer, 0, 4);
 #else
+            // CA2022 violation.
             stream.Read(buffer, 0, 4);
 #endif
             return BitConverter.ToInt32(buffer, 0);

--- a/examples/Console/Fantasy.Console.Entity/Entry.cs
+++ b/examples/Console/Fantasy.Console.Entity/Entry.cs
@@ -9,7 +9,7 @@ public static class Entry
     private static Session _session;
     public static async FTask Show()
     {
-        _scene = await Fantasy.Scene.Create(SceneRuntimeType.MainThread);
+        _scene = await Fantasy.Scene.Create(SceneRuntimeMode.MainThread);
         _session = _scene.Connect(
             "127.0.0.1:20000",
             NetworkProtocolType.KCP,

--- a/examples/Console/Fantasy.Console.Main/Program.cs
+++ b/examples/Console/Fantasy.Console.Main/Program.cs
@@ -3,7 +3,7 @@ using Fantasy.Console.Entity;
 
 SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
 Fantasy.Log.Register(new ConsoleLog());
-Fantasy.Platform.Console.Entry.Initialize(typeof(Fantasy.Console.Entity.Entry).Assembly);
+await Fantasy.Platform.Console.Entry.Initialize(typeof(Fantasy.Console.Entity.Entry).Assembly);
 Fantasy.Platform.Console.Entry.StartUpdate();
 Log.Debug($"{Thread.CurrentThread.ManagedThreadId} SynchronizationContext.Current:{SynchronizationContext.Current}");
 Entry.Show().Coroutine();


### PR DESCRIPTION
1. 有几处FTask增加await执行
2. stream.**Read**(buffer, 0, 8); 调用时的 CA2022 violation 警告，实际应该使用stream.**ReadExactly**(buffer, 0, 8);
3. Fantasy.Scene.Create(**SceneRuntimeType.MainThread)**;时的调用错误，改为了Fantasy.Scene.Create(**SceneRuntimeMode.MainThread**);