### PR TITLE
【数据库访问层14点改进】

### DIFF
--- a/Fantasy.Net/Fantasy.Net/Fantasy.Net.csproj
+++ b/Fantasy.Net/Fantasy.Net/Fantasy.Net.csproj
@@ -42,22 +42,36 @@
 
     <ItemGroup>
       <PackageReference Include="CommandLineParser" Version="2.9.1" />
-      <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+      <FrameworkReference Include="Microsoft.AspNetCore.App" />
+      <PackageReference Include="Dapper" Version="2.1.66" />
       <PackageReference Include="MongoDB.Bson" Version="3.4.3" />
       <PackageReference Include="MongoDB.Driver" Version="3.4.3" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+      <PackageReference Include="Npgsql" Version="9.0.4" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
       <PackageReference Include="protobuf-net" Version="3.2.56" />
     </ItemGroup>
 
     <ItemGroup>
         <None Include="Fantasy-Net.targets" Pack="true" PackagePath="buildTransitive" />
-        <None Include="icon.png" Pack="true" PackagePath="\"/>
-        <None Include="LICENSE" Pack="true" PackagePath="\"/>
-        <None Include="README.md" Pack="true" PackagePath="\"/>
+        <None Include="icon.png" Pack="true" PackagePath="\" />
+        <None Include="LICENSE" Pack="true" PackagePath="\" />
+        <None Include="README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
       <PackageReference Include="System.IO.Pipelines" Version="9.0.8" />
+    </ItemGroup>
+
+    <!-- Source Generator Reference -->
+    <ItemGroup>
+      <ProjectReference Include="..\Fantasy.SourceGenerator\Fantasy.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" SetTargetFramework="TargetFramework=netstandard2.0" />
+    </ItemGroup>
+
+    <!-- 将 Source Generator 打包到 NuGet -->
+    <ItemGroup>
+        <!-- 获取 Fantasy.SourceGenerator 的输出 DLL -->
+        <None Include="..\Fantasy.SourceGenerator\bin\$(Configuration)\netstandard2.0\Fantasy.SourceGenerator.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>
 
     <!-- Source Generator Reference -->

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/DataBase/DataBaseType.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/DataBase/DataBaseType.cs
@@ -1,20 +1,26 @@
 // ReSharper disable CheckNamespace
 // ReSharper disable InconsistentNaming
 #if FANTASY_NET
-namespace Fantasy.DataBase;
 
-/// <summary>
-/// 数据库类型
-/// </summary>
-public enum DataBaseType
+namespace Fantasy.Database
 {
     /// <summary>
-    /// 默认
+    /// 数据库类型
     /// </summary>
-    None = 0,
-    /// <summary>
-    /// MongoDB
-    /// </summary>
-    MongoDB = 1
+    public enum DatabaseType
+    {
+        /// <summary>
+        /// 无
+        /// </summary>
+        None = 0,
+        /// <summary>
+        /// PostgreSQL, 适用于强关系型数据的存储、复杂跨表聚合、强事务性操作
+        /// </summary>
+        PostgreSQL = 1,
+        /// <summary>
+        /// MongoDB, 适用于弱关系型、非结构化的、文档型数据存储和查询
+        /// </summary>
+        MongoDB = 2,
+    }
 }
 #endif

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/DataBase/IDataBase.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/DataBase/IDataBase.cs
@@ -1,32 +1,40 @@
 #if FANTASY_NET
-using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
 using Fantasy.Async;
 using Fantasy.Entitas;
+using Fantasy.Serialize;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using MongoDB.Driver;
+using MongoDB.Driver.Core.Connections;
+using Npgsql;
+using System;
+using System.Linq.Expressions;
 // ReSharper disable InconsistentNaming
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
 
 #pragma warning disable CS8625
 
-namespace Fantasy.DataBase
+namespace Fantasy.Database
 {
     /// <summary>
     /// 数据库设置助手
     /// </summary>
-    public static class DataBaseSetting
+    public static class DatabaseSetting
     {
         /// <summary>
-        /// 初始化自定义委托，当设置了这个委托后，就不会自动创建MongoClient，需要自己在委托里创建MongoClient。
+        /// PostgreSQL 初始化自定义委托, 当设置了这个委托后，就不会自动创建PgSQL连接源, 把创建权交给自定义。
         /// </summary>
-        public static Func<DataBaseCustomConfig, MongoClient>? MongoDBCustomInitialize;
+        public static Func<DatabaseCustomConfig, NpgsqlDataSource>? PostgreSQLCustomInitialize;
+        /// <summary>
+        /// MongoDB 初始化自定义委托，当设置了这个委托后，就不会自动创建MongoClient，把创建权交给自定义。
+        /// </summary>
+        public static Func<DatabaseCustomConfig, MongoClient>? MongoDBCustomInitialize;
     }
 
     /// <summary>
-    /// MongoDB自定义连接参数
+    /// 数据库自定义连接参数
     /// </summary>
-    public sealed class DataBaseCustomConfig
+    public sealed class DatabaseCustomConfig
     {
         /// <summary>
         /// 当前Scene
@@ -41,169 +49,232 @@ namespace Fantasy.DataBase
         /// </summary>
         public string DBName;
     }
-    
+
     /// <summary>
-    /// 表示用于执行各种数据库操作的数据库接口。
+    /// 原生操作柄接口
     /// </summary>
-    public interface IDataBase : IDisposable
+    public interface IRawHandler<H>
     {
         /// <summary>
-        /// 获得当前数据的类型
+        /// 原生操作柄
         /// </summary>
-        public DataBaseType GetDataBaseType { get;}
+        public H RawHandler { get; }
+    }
+
+    /// <summary>
+    /// 数据库基本接口。
+    /// </summary>
+    public interface IDatabase : IDisposable
+    {
         /// <summary>
-        /// 获得对应数据的操作实例
+        /// 所在Scene
         /// </summary>
-        /// <returns>如MongoDB就是IMongoDatabase</returns>
-        public object GetDataBaseInstance { get;}
+        public Scene Scene { get; }
+
         /// <summary>
-        /// 初始化数据库连接。
+        /// 获得当前数据库的类型
         /// </summary>
-        IDataBase Initialize(Scene scene, string connectionString, string dbName);
+        public DatabaseType GetDatabaseType { get;}
+
         /// <summary>
-        /// 在指定的集合中检索类型 <typeparamref name="T"/> 的实体数量。
+        /// 获得当前数据库的工作职责标识
         /// </summary>
-        FTask<long> Count<T>(string collection = null) where T : Entity;
+        public int Duty { get; }
+
         /// <summary>
-        /// 在指定的集合中检索满足给定筛选条件的类型 <typeparamref name="T"/> 的实体数量。
+        /// 序列化器
         /// </summary>
-        FTask<long> Count<T>(Expression<Func<T, bool>> filter, string collection = null) where T : Entity;
+        public ISerialize Serializer { get; }
+
         /// <summary>
-        /// 检查指定集合中是否存在类型 <typeparamref name="T"/> 的实体。
+        /// 初始化数据库。
         /// </summary>
-        FTask<bool> Exist<T>(string collection = null) where T : Entity;
+        IDatabase Initialize(Scene scene, ref ServiceCollection servicec, int duty, string connectionString, string dbName);
+        
         /// <summary>
-        /// 检查指定集合中是否存在满足给定筛选条件的类型 <typeparamref name="T"/> 的实体。
+        /// 使用数据库会话, 返回一个作用域；out一个Session, 通过Session操作数据库。
+        /// <param name="dbSession">dbSession 获得一个新的数据库会话</param>
+        /// <param name="useSessionFromPool">useSessionFromPool 是否从池中获取会话</param>
         /// </summary>
-        FTask<bool> Exist<T>(Expression<Func<T, bool>> filter, string collection = null) where T : Entity;
+        public AsyncServiceScope Use(out IDbSession? dbSession, bool useSessionFromPool = true);
+
         /// <summary>
-        /// 从指定集合中检索指定 ID 的类型 <typeparamref name="T"/> 的实体，不锁定。
+        /// 传入异步函数, 通过委托直接操作数据库。
+        /// 注意 ：如果传入的函数闭包了外部变量, 编译器将会自动生成DisplayClass, 导致一定的GC压力。
         /// </summary>
-        FTask<T> QueryNotLock<T>(long id, bool isDeserialize = false, string collection = null) where T : Entity;
+        /// <param name="asyncFunc">asyncFunc 传入一个异步FTask函数</param>
+        /// <param name="useSessionFromPool">useSessionFromPool 是否从池中获取会话</param>
+        /// <returns></returns>
+        public FTask Invoke(Func<IDbSession?, FTask> asyncFunc, bool useSessionFromPool = true);
+
         /// <summary>
-        /// 从指定集合中检索指定 ID 的类型 <typeparamref name="T"/> 的实体。
+        /// 快速部署, 用于开发时 一次性快速创建所有标记了 [Table] 或 [FTable] 的存储集。
         /// </summary>
-        FTask<T> Query<T>(long id, bool isDeserialize = false, string collection = null) where T : Entity;
+        FTask FastDeploy();
+
+        /// <summary>
+        /// 清空逻辑数据库。用于开发时 将整个数据库全部清除(危险操作, 仅开发时快速迭代期使用，仅针对数据库超级用户进行)
+        /// </summary>
+        FTask DropEverything();
+
+        /// <summary>
+        /// 在指定的存储集中创建索引，以提高类型 <typeparamref name="T"/> 实体的查询性能。
+        /// </summary>
+        FTask CreateIndex<T>(string name, params object[] keys) where T : Entity;
+
+        /// <summary>
+        /// 在默认存储集中创建索引，以提高类型 <typeparamref name="T"/> 实体的查询性能。
+        /// </summary>
+        FTask CreateIndex<T>(params object[] keys) where T : Entity;
+
+        /// <summary>
+        /// 创建指定类型 <typeparamref name="T"/> 的存储集，用于存储实体。
+        /// </summary>
+        FTask CreateDbSet<T>(string Name = null) where T : Entity;
+
+        /// <summary>
+        /// 根据指定类型创建存储集，用于存储实体。
+        /// </summary>
+        FTask CreateDbSet(Type type, string Name = null);
+    }
+
+    /// <summary>
+    /// 表示用于执行数据库 CRUD 操作的数据库会话接口
+    /// </summary>
+    public interface IDbSession : IDisposable,IAsyncDisposable
+    {
+        /// <summary>
+        /// 在指定的存储集中检索类型 <typeparamref name="T"/> 的实体数量。
+        /// </summary>
+        FTask<long> Count<T>(string name = null) where T : Entity;
+        /// <summary>
+        /// 在指定的存储集中检索满足给定筛选条件的类型 <typeparamref name="T"/> 的实体数量。
+        /// </summary>
+        FTask<long> Count<T>(Expression<Func<T, bool>> filter, string name = null) where T : Entity;
+        /// <summary>
+        /// 快速估算实体
+        /// </summary>
+        FTask<long> FastCount<T>(string name = null) where T : Entity;
+        /// <summary>
+        /// 检查指定存储集中是否存在类型 <typeparamref name="T"/> 的实体。
+        /// </summary>
+        FTask<bool> Exist<T>(string name = null) where T : Entity;
+        /// <summary>
+        /// 检查指定存储集中是否存在满足给定筛选条件的类型 <typeparamref name="T"/> 的实体。
+        /// </summary>
+        FTask<bool> Exist<T>(Expression<Func<T, bool>> filter, string name = null) where T : Entity;
+        /// <summary>
+        /// 从指定存储集中检索指定 ID 的类型 <typeparamref name="T"/> 的实体，不锁定。
+        /// </summary>
+        FTask<T> QueryNotLock<T>(long id, bool isDeserialize = false, string name = null) where T : Entity;
+        /// <summary>
+        /// 从指定存储集中检索指定 ID 的类型 <typeparamref name="T"/> 的实体。
+        /// </summary>
+        FTask<T> Query<T>(long id, bool isDeserialize = false, string name = null) where T : Entity;
         /// <summary>
         /// 按页查询满足给定筛选条件的类型 <typeparamref name="T"/> 的实体数量和日期。
         /// </summary>
-        FTask<(int count, List<T> dates)> QueryCountAndDatesByPage<T>(Expression<Func<T, bool>> filter, int pageIndex, int pageSize, bool isDeserialize = false, string collection = null) where T : Entity;
+        FTask<(int count, List<T> dates)> QueryCountAndDatesByPage<T>(Expression<Func<T, bool>> filter, int pageIndex, int pageSize, bool isDeserialize = false, string name = null) where T : Entity;
         /// <summary>
         /// 按页查询满足给定筛选条件的类型 <typeparamref name="T"/> 的实体数量和日期。
         /// </summary>
-        FTask<(int count, List<T> dates)> QueryCountAndDatesByPage<T>(Expression<Func<T, bool>> filter, int pageIndex, int pageSize, string[] cols, bool isDeserialize = false, string collection = null) where T : Entity;
+        FTask<(int count, List<T> dates)> QueryCountAndDatesByPage<T>(Expression<Func<T, bool>> filter, int pageIndex, int pageSize, string[] cols, bool isDeserialize = false, string name = null) where T : Entity;
         /// <summary>
-        /// 分页查询指定集合中满足给定筛选条件的类型 <typeparamref name="T"/> 的实体列表。
+        /// 分页查询指定存储集中满足给定筛选条件的类型 <typeparamref name="T"/> 的实体列表。
         /// </summary>
-        FTask<List<T>> QueryByPage<T>(Expression<Func<T, bool>> filter, int pageIndex, int pageSize, bool isDeserialize = false, string collection = null) where T : Entity;
+        FTask<List<T>> QueryByPage<T>(Expression<Func<T, bool>> filter, int pageIndex, int pageSize, bool isDeserialize = false, string name = null) where T : Entity;
         /// <summary>
-        /// 分页查询指定集合中满足给定筛选条件的类型 <typeparamref name="T"/> 的实体列表，仅返回指定列的数据。
+        /// 分页查询指定存储集中满足给定筛选条件的类型 <typeparamref name="T"/> 的实体列表，仅返回指定列的数据。
         /// </summary>
-        FTask<List<T>> QueryByPage<T>(Expression<Func<T, bool>> filter, int pageIndex, int pageSize, string[] cols, bool isDeserialize = false, string collection = null) where T : Entity;
+        FTask<List<T>> QueryByPage<T>(Expression<Func<T, bool>> filter, int pageIndex, int pageSize, string[] cols, bool isDeserialize = false, string name = null) where T : Entity;
         /// <summary>
-        /// 从指定集合中按页查询满足给定筛选条件的类型 <typeparamref name="T"/> 的实体列表，按指定字段排序。
+        /// 从指定存储集中按页查询满足给定筛选条件的类型 <typeparamref name="T"/> 的实体列表，按指定字段排序。
         /// </summary>
-        FTask<List<T>> QueryByPageOrderBy<T>(Expression<Func<T, bool>> filter, int pageIndex, int pageSize, Expression<Func<T, object>> orderByExpression, bool isAsc = true, bool isDeserialize = false, string collection = null) where T : Entity;
+        FTask<List<T>> QueryByPageOrderBy<T>(Expression<Func<T, bool>> filter, int pageIndex, int pageSize, Expression<Func<T, object>> orderByExpression, bool isAsc = true, bool isDeserialize = false, string name = null) where T : Entity;
         /// <summary>
-        /// 检索满足给定筛选条件的类型 <typeparamref name="T"/> 的第一个实体，从指定集合中。
+        /// 检索满足给定筛选条件的类型 <typeparamref name="T"/> 的第一个实体，从指定存储集中。
         /// </summary>
-        FTask<T?> First<T>(Expression<Func<T, bool>> filter, bool isDeserialize = false, string collection = null) where T : Entity;
+        FTask<T?> First<T>(Expression<Func<T, bool>> filter, bool isDeserialize = false, string name = null) where T : Entity;
         /// <summary>
-        /// 查询指定集合中满足给定 JSON 查询字符串的类型 <typeparamref name="T"/> 的第一个实体，仅返回指定列的数据。
+        /// 查询指定存储集中满足给定 JSON 查询字符串的类型 <typeparamref name="T"/> 的第一个实体，仅返回指定列的数据。
         /// </summary>
-        FTask<T> First<T>(string json, string[] cols, bool isDeserialize = false, string collection = null) where T : Entity;
+        FTask<T> First<T>(string json, string[] cols, bool isDeserialize = false, string name = null) where T : Entity;
         /// <summary>
-        /// 从指定集合中按页查询满足给定筛选条件的类型 <typeparamref name="T"/> 的实体列表，按指定字段排序。
+        /// 从指定存储集中按页查询满足给定筛选条件的类型 <typeparamref name="T"/> 的实体列表，按指定字段排序。
         /// </summary>
-        FTask<List<T>> QueryOrderBy<T>(Expression<Func<T, bool>> filter, Expression<Func<T, object>> orderByExpression, bool isAsc = true, bool isDeserialize = false, string collection = null) where T : Entity;
+        FTask<List<T>> QueryOrderBy<T>(Expression<Func<T, bool>> filter, Expression<Func<T, object>> orderByExpression, bool isAsc = true, bool isDeserialize = false, string name = null) where T : Entity;
         /// <summary>
-        /// 从指定集合中按页查询满足给定筛选条件的类型 <typeparamref name="T"/> 的实体列表。
+        /// 从指定存储集中按页查询满足给定筛选条件的类型 <typeparamref name="T"/> 的实体列表。
         /// </summary>
-        FTask<List<T>> Query<T>(Expression<Func<T, bool>> filter, bool isDeserialize = false, string collection = null) where T : Entity;
+        FTask<List<T>> Query<T>(Expression<Func<T, bool>> filter, bool isDeserialize = false, string name = null) where T : Entity;
         /// <summary>
-        /// 查询指定集合中满足给定筛选条件的类型 <typeparamref name="T"/> 实体列表，仅返回指定字段的数据。
+        /// 查询指定存储集中满足给定筛选条件的类型 <typeparamref name="T"/> 实体列表，仅返回指定字段的数据。
         /// </summary>
-        FTask<List<T>> Query<T>(Expression<Func<T, bool>> filter, Expression<Func<T, object>>[] cols, bool isDeserialize = false, string collection = null) where T : Entity;
+        FTask<List<T>> Query<T>(Expression<Func<T, bool>> filter, Expression<Func<T, object>>[] cols, bool isDeserialize = false, string name = null) where T : Entity;
         /// <summary>
         /// 查询指定 ID 的多个集合，将结果存储在给定的实体列表中。
         /// </summary>
-        FTask Query(long id, List<string> collectionNames, List<Entity> result, bool isDeserialize = false);
+        FTask Query(long id, List<string> nameNames, List<Entity> result, bool isDeserialize = false);
         /// <summary>
-        /// 根据给定的 JSON 查询字符串查询指定集合中的类型 <typeparamref name="T"/> 实体列表。
+        /// 根据给定的 JSON 查询字符串查询指定存储集中的类型 <typeparamref name="T"/> 实体列表。
         /// </summary>
-        FTask<List<T>> QueryJson<T>(string json, bool isDeserialize = false, string collection = null) where T : Entity;
+        FTask<List<T>> QueryJson<T>(string json, bool isDeserialize = false, string name = null) where T : Entity;
         /// <summary>
-        /// 根据给定的 JSON 查询字符串查询指定集合中的类型 <typeparamref name="T"/> 实体列表，仅返回指定列的数据。
+        /// 根据给定的 JSON 查询字符串查询指定存储集中的类型 <typeparamref name="T"/> 实体列表，仅返回指定列的数据。
         /// </summary>
-        FTask<List<T>> QueryJson<T>(string json, string[] cols, bool isDeserialize = false, string collection = null) where T : Entity;
+        FTask<List<T>> QueryJson<T>(string json, string[] cols, bool isDeserialize = false, string name = null) where T : Entity;
         /// <summary>
-        /// 根据给定的 JSON 查询字符串查询指定集合中的类型 <typeparamref name="T"/> 实体列表，通过指定的任务 ID 进行标识。
+        /// 根据给定的 JSON 查询字符串查询指定存储集中的类型 <typeparamref name="T"/> 实体列表，通过指定的任务 ID 进行标识。
         /// </summary>
-        FTask<List<T>> QueryJson<T>(long taskId, string json, bool isDeserialize = false, string collection = null) where T : Entity;
+        FTask<List<T>> QueryJson<T>(long taskId, string json, bool isDeserialize = false, string name = null) where T : Entity;
         /// <summary>
-        /// 查询指定集合中满足给定筛选条件的类型 <typeparamref name="T"/> 实体列表，仅返回指定列的数据。
+        /// 查询指定存储集中满足给定筛选条件的类型 <typeparamref name="T"/> 实体列表，仅返回指定列的数据。
         /// </summary>
-        FTask<List<T>> Query<T>(Expression<Func<T, bool>> filter, string[] cols, bool isDeserialize = false, string collection = null) where T : Entity;
+        FTask<List<T>> Query<T>(Expression<Func<T, bool>> filter, string[] cols, bool isDeserialize = false, string name = null) where T : Entity;
         /// <summary>
-        /// 保存类型 <typeparamref name="T"/> 实体到指定集合中，如果集合不存在将自动创建。
+        /// 保存类型 <typeparamref name="T"/> 实体到指定存储集中。
         /// </summary>
-        FTask Save<T>(T entity, string collection = null) where T : Entity, new();
+        FTask Save<T>(T entity, string name = null) where T : Entity, new();
         /// <summary>
         /// 保存一组实体到数据库中，根据实体列表的 ID 进行区分和存储。
         /// </summary>
         FTask Save(long id, List<Entity> entities);
         /// <summary>
-        /// 通过事务会话将类型 <typeparamref name="T"/> 实体保存到指定集合中，如果集合不存在将自动创建。
+        /// 通过事务会话将类型 <typeparamref name="T"/> 实体保存到指定存储集中。
         /// </summary>
-        FTask Save<T>(object transactionSession, T entity, string collection = null) where T : Entity;
+        FTask Save<T>(object transactionSession, T entity, string name = null) where T : Entity;
         /// <summary>
-        /// 向指定集合中插入一个类型 <typeparamref name="T"/> 实体，如果集合不存在将自动创建。
+        /// 向指定存储集中插入一个类型 <typeparamref name="T"/> 实体。
         /// </summary>
-        FTask Insert<T>(T entity, string collection = null) where T : Entity, new();
+        FTask Insert<T>(T entity, string name = null) where T : Entity, new();
         /// <summary>
-        /// 批量插入一组类型 <typeparamref name="T"/> 实体到指定集合中，如果集合不存在将自动创建。
+        /// 批量插入一组类型 <typeparamref name="T"/> 实体到指定存储集中。
         /// </summary>
-        FTask InsertBatch<T>(IEnumerable<T> list, string collection = null) where T : Entity, new();
+        FTask InsertBatch<T>(IEnumerable<T> list, string name = null) where T : Entity, new();
         /// <summary>
-        /// 通过事务会话，批量插入一组类型 <typeparamref name="T"/> 实体到指定集合中，如果集合不存在将自动创建。
+        /// 通过事务会话，批量插入一组类型 <typeparamref name="T"/> 实体到指定存储集中。
         /// </summary>
-        FTask InsertBatch<T>(object transactionSession, IEnumerable<T> list, string collection = null) where T : Entity, new();
+        FTask InsertBatch<T>(object transactionSession, IEnumerable<T> list, string name = null) where T : Entity, new();
         /// <summary>
         /// 通过事务会话，根据指定的 ID 从数据库中删除指定类型 <typeparamref name="T"/> 实体。
         /// </summary>
-        FTask<long> Remove<T>(object transactionSession, long id, string collection = null) where T : Entity, new();
+        FTask<long> Remove<T>(object transactionSession, long id, string name = null) where T : Entity, new();
         /// <summary>
         /// 根据指定的 ID 从数据库中删除指定类型 <typeparamref name="T"/> 实体。
         /// </summary>
-        FTask<long> Remove<T>(long id, string collection = null) where T : Entity, new();
+        FTask<long> Remove<T>(long id, string name = null) where T : Entity, new();
         /// <summary>
         /// 通过事务会话，根据给定的筛选条件从数据库中删除指定类型 <typeparamref name="T"/> 实体。
         /// </summary>
-        FTask<long> Remove<T>(long coroutineLockQueueKey, object transactionSession, Expression<Func<T, bool>> filter, string collection = null) where T : Entity, new();
+        FTask<long> Remove<T>(long coroutineLockQueueKey, object transactionSession, Expression<Func<T, bool>> filter, string name = null) where T : Entity, new();
         /// <summary>
         /// 根据给定的筛选条件从数据库中删除指定类型 <typeparamref name="T"/> 实体。
         /// </summary>
-        FTask<long> Remove<T>(long coroutineLockQueueKey, Expression<Func<T, bool>> filter, string collection = null) where T : Entity, new();
+        FTask<long> Remove<T>(long coroutineLockQueueKey, Expression<Func<T, bool>> filter, string name = null) where T : Entity, new();
         /// <summary>
-        /// 根据给定的筛选条件计算指定集合中类型 <typeparamref name="T"/> 实体某个属性的总和。
+        /// 根据给定的筛选条件计算指定存储集中类型 <typeparamref name="T"/> 实体某个属性的总和。
         /// </summary>
-        FTask<long> Sum<T>(Expression<Func<T, bool>> filter, Expression<Func<T, object>> sumExpression, string collection = null) where T : Entity;
-        /// <summary>
-        /// 在指定的集合中创建索引，以提高类型 <typeparamref name="T"/> 实体的查询性能。
-        /// </summary>
-        FTask CreateIndex<T>(string collection, params object[] keys) where T : Entity;
-        /// <summary>
-        /// 在默认集合中创建索引，以提高类型 <typeparamref name="T"/> 实体的查询性能。
-        /// </summary>
-        FTask CreateIndex<T>(params object[] keys) where T : Entity;
-        /// <summary>
-        /// 创建指定类型 <typeparamref name="T"/> 的数据库，用于存储实体。
-        /// </summary>
-        FTask CreateDB<T>() where T : Entity;
-        /// <summary>
-        /// 根据指定类型创建数据库，用于存储实体。
-        /// </summary>
-        FTask CreateDB(Type type);
+        FTask<long> Sum<T>(Expression<Func<T, bool>> filter, Expression<Func<T, object>> sumExpression, string name = null) where T : Entity;
     }
 }
 

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/DataBase/World.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/DataBase/World.cs
@@ -1,22 +1,66 @@
 #pragma warning disable CS8603 // Possible null reference return.
 #if FANTASY_NET
+using Fantasy.Database;
 using Fantasy.Platform.Net;
+using Microsoft.Extensions.DependencyInjection;
+using System;
 
-namespace Fantasy.DataBase
+namespace Fantasy
 {
     /// <summary>
-    /// 表示一个游戏世界。
+    /// 表示一个服务器【世界】
     /// </summary>
     public sealed class World : IDisposable
     {
         /// <summary>
-        /// 获取游戏世界的唯一标识。
+        /// 获取世界的唯一标识。
         /// </summary>
         public byte Id { get; private init; }
         /// <summary>
-        /// 获取游戏世界的数据库接口。
+        /// 世界名。
         /// </summary>
-        public IDataBase DataBase { get; private init; }
+        public string Name { get; private init; }
+        /// <summary>
+        /// 本世界的服务注册和提供者
+        /// </summary>
+        internal ServiceProvider ServiceProvider { get; init; }
+        /// <summary>
+        /// 本世界所有数据库, 按照工作职责号存取。
+        /// </summary>
+        private Dictionary<int, IDatabase> AllDatabases { get; init; }
+
+        /// <summary>
+        /// 根据工作职责号获取某个类型的数据库。
+        /// </summary>
+        /// <typeparam name="T">数据库类型</typeparam>
+        /// <param name="duty">数据库工作职责号</param>
+        /// <returns></returns>
+        public T? GetDatabase<T>(int duty) where T : class, IDatabase
+        {
+            if(!AllDatabases.TryGetValue(duty, out IDatabase? database))
+                return null;
+
+            var res = database as T;
+            return res;
+        }
+
+        /// <summary>
+        /// 重载方法, 根据工作职责号获取数据库接口。
+        /// 拿到接口后, 可以有两种用法:
+        /// 1. 强类型用法，转为对应的类型, 按照PostgreSQL、MongoDb等特定类型使用。
+        /// 2. 弱类型用法，直接使用IDatabase接口, 调用其中 DbSession 内部的通用方法，适合简单CRUD。
+        /// </summary>
+        /// <param name="duty">数据库工作职责号</param>
+        /// <returns></returns>
+        public IDatabase? GetDatabase(int duty)
+        {
+            if (!AllDatabases.TryGetValue(duty, out IDatabase? database))
+                return null;
+
+            var res = database;
+            return res;
+        }
+
         /// <summary>
         /// 获取游戏世界的配置信息。
         /// </summary>
@@ -29,23 +73,63 @@ namespace Fantasy.DataBase
         /// <param name="worldConfigId"></param>
         private World(Scene scene, byte worldConfigId)
         {
-            Id = worldConfigId;
+            Id = worldConfigId;            
             var worldConfig = Config;
-            var dbType = worldConfig.DbType.ToLower();
+            Name = Config.WorldName;
+            var services = new ServiceCollection();
+            services.AddHttpContextAccessor();
 
-            switch (dbType)
+            AllDatabases = [];
+            for(int i = 0; i < worldConfig.DbType.Length; i++)
             {
-                case "mongodb":
+                if (string.IsNullOrWhiteSpace(worldConfig.DbConnection[i]))
+                    continue;
+
+                string dbType = worldConfig.DbType[i].ToLower();
+                switch (dbType)
                 {
-                    DataBase = new MongoDataBase();
-                    DataBase.Initialize(scene, worldConfig.DbConnection, worldConfig.DbName);
-                    break;
-                }
-                default:
-                {
-                    throw new Exception("No supported database");
+                    case "postgresql":
+                    case "postgres":
+                    case "pgsql":
+                    case "pg":
+                        {
+                            if (AllDatabases.ContainsKey(worldConfig.DbDuty[i]))
+                                throw new Exception($"Database {worldConfig.DbName[i]} Duty({worldConfig.DbDuty[i]}) is duplicated. Please verify your configuration.");
+                            
+                            var pg = new PgSQL();
+                            pg.Initialize(scene,ref services, worldConfig.DbDuty[i], worldConfig.DbConnection[i], worldConfig.DbName[i]);
+                            AllDatabases.Add(worldConfig.DbDuty[i], pg);
+                            break;
+                        }
+                    case "mongodb":
+                    case "mongo":
+                        {
+                            if (AllDatabases.ContainsKey(worldConfig.DbDuty[i]))
+                                throw new Exception($"Database {worldConfig.DbName[i]} Duty({worldConfig.DbDuty[i]}) is duplicated. Please verify your configuration.");
+                            
+                            var mongo = new Mongo();
+                            mongo.Initialize(scene, ref services, worldConfig.DbDuty[i], worldConfig.DbConnection[i], worldConfig.DbName[i]);
+                            AllDatabases.Add(worldConfig.DbDuty[i], mongo);                           
+                            break;
+                        }
+                    default:
+                        {
+                            throw new Exception("Not supported database type.");
+                        }
                 }
             }
+            if (AllDatabases.Count == 0)
+            { 
+                Log.Warning($" Warning : Has no available database ! (World id:{Id})(Scene configId:{scene.SceneConfigId})");
+            }
+            else
+            {
+                Log.Debug($"(World id:{Id})(Scene configId:{scene.SceneConfigId}) Has successfully owned {AllDatabases.Count} database(s): "+
+                string.Join("，", AllDatabases.Select((kv, index) =>
+                $"{index + 1}.{kv.Value.GetDatabaseType} (Duty {kv.Key})")));   //依次打印世界中可用数据库的简要信息
+            }
+
+            ServiceProvider = services.BuildServiceProvider();  //构建服务中心
         }
 
         /// <summary>
@@ -61,7 +145,9 @@ namespace Fantasy.DataBase
                 return null;
             }
 
-            return string.IsNullOrEmpty(worldConfigData.DbConnection) ? null : new World(scene, id);
+            return (worldConfigData.DbConnection == null || worldConfigData.DbConnection.Length == 0)
+            ? null
+            : new World(scene, id);
         }
 
         /// <summary>
@@ -69,7 +155,7 @@ namespace Fantasy.DataBase
         /// </summary>
         public void Dispose()
         {
-            DataBase.Dispose();
+            AllDatabases.Clear();
         }
     }
 }

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Database/Attributes/FTableAttribute.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Database/Attributes/FTableAttribute.cs
@@ -1,0 +1,43 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Fantasy.Database.Attributes
+{
+    /// <summary>
+    /// [FTable] 是 Fantasy 对原生 [Table]标签的扩展, 设计用于加强对SQL数据库的分表、表迁移等情况的管理。
+    /// 打上这个标签, 框架会为该类建立"Entity-Table"映射。
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, Inherited = false)]
+    public sealed class FTableAttribute : TableAttribute
+    {
+        /// <summary>
+        /// 表描述
+        /// </summary>
+        public string? Description { get; set; }
+
+        #region TODO-LIST 这些特性以后再做
+        ///// <summary>
+        ///// 禁止整表更新
+        ///// </summary>
+        //public bool NoBulkUpdate { get; set; } = false;
+
+        ///// <summary>
+        ///// 禁止整表删除
+        ///// </summary>
+        //public bool NoBulkDelete { get; set; } = false;
+
+        ///// <summary>
+        ///// 是否启用分表
+        ///// </summary>
+        //public bool EnableSharding { get; set; } = false;
+        #endregion
+
+        /// <summary>
+        /// 构造函数
+        /// </summary>
+        /// <param name="name"></param>
+        public FTableAttribute(string? name = null) : base(name ?? "")
+        {
+            
+        }
+    }
+}

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Database/FTableHelper.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Database/FTableHelper.cs
@@ -1,0 +1,90 @@
+﻿using Fantasy.Assembly;
+using Fantasy.Async;
+using Fantasy.Database.Attributes;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fantasy.Database
+{
+    internal static class FTableHelper
+    {
+        /// <summary>
+        /// 扫描程序集中所有含有[Table]或[FTable]标签的类型, 并进行操作
+        /// <param name="doSomethingWithFTableAndTableName"> 拿到FTable的类型和表名, 针对性地进行操作。</param>
+        /// </summary>       
+        public static void ScanFTableTypes(Action<Type,string> doSomethingWithFTableAndTableName) {
+
+            foreach (var kv in AssemblyManifest.Manifests)
+            {
+                var assm = kv.Value.Assembly;
+
+                //Log.Info($"Scanning for FTables in assembly: {assm.FullName}");
+
+                var FTables = assm.GetTypes()
+                  .Where(t => t.IsClass && !t.IsAbstract)
+                  .Where(t => t.GetCustomAttributes(typeof(TableAttribute), true).Any());
+
+                foreach (var type in FTables)
+                {
+                    // 优先检查 FantasyTableAttribute.Name，其次检查 TableAttribute.Name
+                    string? tableName = null;
+                    var fantasyAttr = type.GetCustomAttribute<FTableAttribute>();
+                    if (fantasyAttr != null && !string.IsNullOrWhiteSpace(fantasyAttr.Name))
+                        tableName = fantasyAttr.Name;
+                    else
+                    {
+                        var tableAttr = type.GetCustomAttribute<TableAttribute>();
+                        if (tableAttr != null && !string.IsNullOrWhiteSpace(tableAttr.Name))
+                            tableName = tableAttr.Name;
+                    }
+
+                    // 没有用标签设置自定义表名, 那就直接用类名作为表名
+                    tableName ??= $"{type.Name}";
+
+                    doSomethingWithFTableAndTableName.Invoke(type, tableName);
+                }
+            }
+        }
+        /// <summary>
+        /// 异步版本,传入异步函数
+        /// </summary>
+        public static async FTask ScanFTableTypesAsync(Func<Type, string, FTask> doSomethingWithFTableAndTableName)
+        {
+            foreach (var kv in AssemblyManifest.Manifests)
+            {
+                var assm = kv.Value.Assembly;
+
+                Log.Info($"Scanning assembly: {assm.FullName}");
+
+                var FTables = assm.GetTypes()
+                    .Where(t => t.IsClass && !t.IsAbstract)
+                    .Where(t => t.GetCustomAttributes(typeof(TableAttribute), true).Any());
+
+                foreach (var type in FTables)
+                {
+                    string? tableName = null;
+                    var fantasyAttr = type.GetCustomAttribute<FTableAttribute>();
+                    if (fantasyAttr != null && !string.IsNullOrWhiteSpace(fantasyAttr.Name))
+                        tableName = fantasyAttr.Name;
+                    else
+                    {
+                        var tableAttr = type.GetCustomAttribute<TableAttribute>();
+                        if (tableAttr != null && !string.IsNullOrWhiteSpace(tableAttr.Name))
+                            tableName = tableAttr.Name;
+                    }
+
+                    tableName ??= type.Name;
+
+                    // await 调用异步方法
+                    await doSomethingWithFTableAndTableName(type, tableName);
+                }
+            }
+        }
+    }
+}

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Database/MongoDB.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Database/MongoDB.cs
@@ -1,0 +1,320 @@
+#if FANTASY_NET
+using Fantasy.Assembly;
+using Fantasy.Async;
+using Fantasy.Database.Attributes;
+using Fantasy.Entitas;
+using Fantasy.Helper;
+using Fantasy.Serialize;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using System.Collections.Concurrent;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading.Channels;
+using static System.Formats.Asn1.AsnWriter;
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
+#pragma warning disable CS8603 // Possible null reference return.
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+namespace Fantasy.Database
+{
+    /// <summary>
+    /// Fantasy框架使用 Mongo 数据库的实现。
+    /// </summary>
+    public sealed partial class MongoDb : IDatabase, IRawHandler<IMongoDatabase>
+    {
+        private MongoClient _mongoClient;
+        private MongoSession _dbSession;
+        internal FTaskFlowLock FlowLock { get; private set; }
+        internal const int FTaskCountLimit = 1024;
+
+        /// <summary>
+        /// Scene
+        /// </summary>
+        public Scene Scene { get; private set; }
+        /// <summary>
+        /// 序列化器
+        /// </summary>
+        public ISerialize Serializer { get; private set; }
+        /// <summary>
+        /// 所有集合名
+        /// </summary>
+        public readonly HashSet<string> Collections = new HashSet<string>();
+        /// <summary>
+        /// 获得当前数据的类型
+        /// </summary>
+        public DatabaseType GetDatabaseType { get; } = DatabaseType.MongoDB;
+        /// <summary>
+        /// 这个数据库的工作职责
+        /// </summary>
+        public int Duty { get; private set; }
+        /// <summary>
+        /// 获得Mongo数据库的原生操作柄
+        /// </summary>
+        public IMongoDatabase RawHandler { get; private set; }
+
+        #region Basic
+
+        /// <summary>
+        /// 初始化 MongoDB 数据库连接并记录所有集合名。
+        /// </summary>
+        ///  <param name="scene">场景对象。</param>
+        ///  <param name="worldServices">服务注册。</param>
+        /// <param name="duty">工作职责。</param>
+        /// <param name="connectionString">数据库连接字符串。</param>
+        /// <param name="dbName">数据库名称。</param>
+        /// <returns>初始化后的数据库实例。</returns>
+        public IDatabase Initialize(Scene scene,ref ServiceCollection worldServices, int duty, string connectionString, string dbName)
+        {
+            this.Scene = scene;
+            Duty = duty;
+
+            if(DatabaseSetting.MongoDBCustomInitialize != null)
+            {
+                _mongoClient = DatabaseSetting.MongoDBCustomInitialize(new DatabaseCustomConfig()
+                {
+                    Scene = scene,
+                    ConnectionString = connectionString,
+                    DBName = dbName
+                });
+            }        
+            else
+            {
+                var settings = MongoClientSettings.FromConnectionString(connectionString);
+                settings.MaxConnectionPoolSize = 200;
+                _mongoClient = new MongoClient(settings);
+            }
+
+            try
+            {
+                RawHandler = _mongoClient.GetDatabase(dbName);
+                _dbSession = new MongoSession(this);
+
+                long mongoDbTypeHash = GetType().TypeHandle.Value.ToInt64();
+
+                FlowLock = ( FlowLock == null )
+                        ? new FTaskFlowLock(FTaskCountLimit, scene.CoroutineLockComponent, mongoDbTypeHash)
+                        : FlowLock.Reset(scene.CoroutineLockComponent, mongoDbTypeHash);
+
+                // 记录所有集合名
+                Collections.UnionWith(RawHandler.ListCollectionNames().ToList());
+                if (Collections.Count == 0)
+                    Log.Warning($" ( MongoDb has No collection in \"{dbName}\"!! ) ");
+                else
+                    Log.Info($"(MongoDb has {Collections.Count} collection(s) in \"{dbName}\". )");
+            }
+            catch (Exception ex){
+                throw new Exception($"Mongo logic-database {dbName} connection failed:\n{ex}");
+            }
+
+            Serializer = SerializerManager.GetSerializer(FantasySerializerType.Bson);
+            return this;
+        }
+
+        /// <summary>
+        /// 异步销毁限流锁
+        /// </summary>
+        /// <returns></returns>
+        public async FTask DisposeFlowLockAsync() {
+            await FlowLock.DisposeAsync();
+        }
+
+        /// <summary>
+        /// 销毁释放资源。
+        /// </summary>
+        public void Dispose()
+        {
+            DisposeFlowLockAsync().Coroutine(); // ← 销毁FTaskFlowLock, 注意这里是开了协程的
+            // 清理资源。
+            Serializer = null;
+            RawHandler = null;
+            FlowLock = null;
+            Collections.Clear();
+            _mongoClient.Dispose();
+            _dbSession.Dispose();
+        }
+        #endregion
+
+        #region Use Session
+        /// <summary>
+        /// 使用MongoDb, 返回一个MongoSession。
+        /// 可以链式调用Mongo数据库操作。
+        /// </summary>
+        /// <returns></returns>
+        public MongoSession Use()
+        {
+            return _dbSession;
+        }
+
+        /// <summary>
+        /// 使用MongoDb, 传出一个MongoSession。这里实现了接口中的方法, 让MongoDb与一般的SQL数据库兼容。 
+        /// 事实上, Mongo的连接与一般的SQL数据库不同，它不自动维护了一个连接池, 所以返回的Scope为空, 可以直接放心用out出来的IDbSession就可以了
+        /// </summary>
+        /// <param name="mongoSession"></param>
+        /// <param name="useSessionFromPool">Session池化, Mongo 数据库无需关心</param>
+        /// <returns></returns>
+        public AsyncServiceScope Use(out IDbSession? mongoSession, bool useSessionFromPool = true)
+        {
+            mongoSession = _dbSession;
+            return Scene.World.ServiceProvider.CreateAsyncScope();
+        }
+
+        /// <summary>
+        /// 通过 IDbSession 操作数据库会话。 
+        /// </summary>
+        /// <param name="asyncFunc"></param>
+        /// <param name="useSessionFromPool">Session池化, Mongo 数据库无需关心</param>
+        public async FTask Invoke(Func<IDbSession, FTask> asyncFunc, bool useSessionFromPool = true)
+        {
+           await asyncFunc(_dbSession);
+        }
+        #endregion
+
+        #region Deployment
+
+        /// <summary>
+        /// 快速部署, 一次性快速创建所有标记为 [Table] 或 [FTable] 的实体集合。
+        /// (建议仅开发时使用,正式部署后请走严格的数据库迁移流程)
+        /// </summary>
+        /// <returns></returns>
+        public async FTask FastDeploy()
+        {
+            await FTableHelper.ScanFTableTypesAsync((type, tableName) => CreateCollection(type, tableName));
+        }
+
+        /// <summary>
+        /// 清空逻辑数据库。用于开发时将整个数据库全部清除(危险操作, 仅开发时快速迭代期使用，仅针对数据库超级用户进行)
+        /// </summary>
+        /// <returns></returns>
+        public async FTask DropEverything()
+        {
+            //TODO 
+            await FTask.CompletedTask;
+        }
+
+        /// <summary>
+        /// 创建数据库集合（如果不存在）。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="Name">指定名。</param>
+        public async FTask CreateCollection<T>(string Name = null) where T : Entity
+        {
+            if(string.IsNullOrWhiteSpace(Name))
+            {
+                Name = typeof(T).Name;
+            }
+
+            // 已经存在数据库表
+            if (Collections.Contains(Name))
+            {
+                return;
+            }
+
+            await RawHandler.CreateCollectionAsync(Name);
+
+            Collections.Add(Name);
+        }
+
+        /// <summary>
+        /// 创建数据库集合（如果不存在）。
+        /// </summary>
+        /// <param name="type">实体类型。</param>
+        /// <param name="Name">指定名。</param>
+        public async FTask CreateCollection(Type type, string Name = null)
+        {
+            if (string.IsNullOrWhiteSpace(Name))
+            {
+                Name = type.Name;
+            }
+            if (Collections.Contains(Name))
+            {
+                return;
+            }
+
+            await RawHandler.CreateCollectionAsync(Name);
+
+            Collections.Add(Name);
+        }
+
+        /// <summary>
+        /// 创建指定类型 <typeparamref name="T"/> 的存储集，用于存储实体。
+        /// </summary>
+        public async FTask CreateDbSet<T>(string Name = null) where T : Entity
+        {
+            await CreateCollection<T>(Name);
+        }
+        /// <summary>
+        /// 根据指定类型创建存储集，用于存储实体。
+        /// </summary>
+        public async FTask CreateDbSet(Type type, string Name = null)
+        {
+            await CreateCollection(type, Name);
+        }
+
+        #endregion
+
+        #region Index
+
+        /// <summary>
+        /// 创建数据库索引。
+        /// </summary>
+        /// <param name="collection"></param>
+        /// <param name="keys"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <code>
+        /// 使用例子(可多个):
+        /// 1 : Builders.IndexKeys.Ascending(d=>d.Id)
+        /// 2 : Builders.IndexKeys.Descending(d=>d.Id).Ascending(d=>d.Name)
+        /// 3 : Builders.IndexKeys.Descending(d=>d.Id),Builders.IndexKeys.Descending(d=>d.Name)
+        /// </code>
+        public async FTask CreateIndex<T>(string collection, params object[]? keys) where T : Entity
+        {
+            if (keys == null || keys.Length <= 0)
+            {
+                return;
+            }
+
+            var indexModels = new List<CreateIndexModel<T>>();
+
+            foreach (object key in keys)
+            {
+                IndexKeysDefinition<T> indexKeysDefinition = (IndexKeysDefinition<T>)key;
+
+                indexModels.Add(new CreateIndexModel<T>(indexKeysDefinition));
+            }
+
+            await _dbSession.GetCollection<T>(collection).Indexes.CreateManyAsync(indexModels);
+        }
+
+        /// <summary>
+        /// 创建数据库的索引。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="keys">索引键定义。</param>
+        public async FTask CreateIndex<T>(params object[]? keys) where T : Entity
+        {
+            if (keys == null)
+            {
+                return;
+            }
+
+            List<CreateIndexModel<T>> indexModels = new List<CreateIndexModel<T>>();
+
+            foreach (object key in keys)
+            {
+                IndexKeysDefinition<T> indexKeysDefinition = (IndexKeysDefinition<T>)key;
+
+                indexModels.Add(new CreateIndexModel<T>(indexKeysDefinition));
+            }
+
+            await _dbSession.GetCollection<T>().Indexes.CreateManyAsync(indexModels);
+        }
+
+        #endregion
+    }
+}
+#endif

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Database/PgSession.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Database/PgSession.cs
@@ -1,0 +1,1749 @@
+﻿#if FANTASY_NET
+using Fantasy.Assembly;
+using Fantasy.Async;
+using Fantasy.Database.Attributes;
+using Fantasy.Entitas;
+using Microsoft.EntityFrameworkCore;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Npgsql;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Data;
+using System.Data.Common;
+using System.Linq.Expressions;
+using System.Reflection;
+
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
+#pragma warning disable CS8603 // Possible null reference return.
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+namespace Fantasy.Database
+{
+    /// <summary>
+    /// 选择操作SQL数据库时用哪个ORM。 Dapper略快但会牺牲高级特性。
+    /// </summary>
+    public enum PreferSqlMode
+    {
+        /// <summary>
+        /// 更青睐用EFCore
+        /// </summary>
+        EFCore,
+        /// <summary>
+        /// 更青睐用Dapper
+        /// </summary>
+        Dapper
+    }
+
+    /// <summary>
+    /// 【PgSession是 PgSql 数据库的操作会话, 继承自EFCore 的 DbContext。】
+    /// </summary>
+    /// 
+    /// 【注意, 每个 PgSession 会交由EFCore构建一个“Entity - Table”模型】
+    ///  模型初始化时自动构建, 构建后无法运行时变动! 无法HotUpdate！无法检测到动态新建的表、无法感知热更新建的字段！ 
+    ///  因此，对于已上线的业务，如果需要无感更新业务数据, (典型的情况是中途给实体新增字段 )，
+    ///  请务必考虑采用【蓝绿部署】结合"数据库迁移策略"；
+    ///  另一种可能有效的运行时让服务无感交接的解决办法是：继承并实现额外的DbContext，比如实现一组临时的 TempSession 与 TempSessionUnPooled ，专门用于“Entity - Table”模型的热交接（但即便如此, 等到合适的时机依然需要重启服务器，构建新的模型）。
+    ///  
+    /// 【关于 PgSession 的池化机制】 由ServiceProvider依赖注入进行池化，
+    /// 具体详情请见 PostgreSQL 初始化时调用的 ServiceCollection.AddDbContextPool() 方法，
+    /// 微软在该方法中对 DbContext 的池化做了详细注释。
+    /// 
+    /// 【关于 ORM 性能】PgSession 基于 Dapper和EFCore 封装。
+    /// 从性能来考虑, 4种 SQL 操作方式排名如下——
+    /// 1. 原生SQL: 性能最优, 但没有 ORM 字段自动映射; 
+    /// 2. Dapper: 相当于原生SQL + 自动字段映射, 性能次之;
+    /// 3. EFCore: 如果使用 FromSqlRaw , 性能可能与 Dapper 相当;
+    /// 4. EFCore一般情况: 适合多人合作开发, 提供高级特性, 如导航属性、LINQ 、Change Tracking 、事务管理。
+    /// 当前封装，结合了1 2 3 4，以寻求均衡。
+    /// 为什么当前不用号称速度更快的 ORM 框架，比如SQLSugar ？考虑到，现在AI时代, 复杂查询可以让AI生成最优的原生SQL执行, ORM 的性能不必须作为核心考虑项。  
+    /// 而且许多数据库的高级用法，更常发生在响应非实时的后运营阶段、离线处理阶段，这时SQL执行效率并不追求极限，EFCore完全足以胜任绝大多数状况。
+    ///
+    public partial class PgSession : DbContext, IDbSession, IAssemblyLifecycle
+    {
+        /// <summary>
+        /// Pg的实例引用
+        /// </summary>
+        private PostgreSQL pg;
+        /// <summary>
+        /// 设置Pg实例引用
+        /// </summary>
+        /// <param name="Pg"></param>
+        public void SetPg(PostgreSQL Pg) {
+            pg = Pg;
+        }
+
+        /// <summary>
+        /// 构造函数, 就这样继承就可以了 
+        /// </summary>
+        /// <param name="options"></param>
+        public PgSession(DbContextOptions options) : base(options)
+        {
+
+        }
+
+        /// <summary>
+        /// 非池中取得的PgSession, 劣势: 每次使用都会产生新实例, 相比池化, 会施加轻微GC压力。优势: 绝对的状态安全。
+        /// 调用 PostgreSQL.Use() 时，传入参数设置未非池化， 即可获取 PgSessionUnPooled 实例。
+        /// </summary>
+        public class PgSessionUnPooled : PgSession
+        {
+            /// <summary>
+            /// 构造方法
+            /// </summary>
+            /// <param name="options"></param>
+            public PgSessionUnPooled(DbContextOptions<PgSessionUnPooled> options) : base(options)
+            {
+            }
+        }
+
+        /// <summary>
+        ///  " Entity - Table" 映射模型构建阶段。
+        ///  在 DbContext 首次实例化的时候会自动检查是否建构过模型，如果检测到从未建构过，OnModelCreating 就会生效。  
+        /// </summary>
+        /// <param name="modelBuilder"></param>
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            //Log.Info("\" Entity - Table\" Model is Creating...");
+
+            FTableHelper.ScanFTableTypes((type, tableName) => {
+                //Log.Debug($"Registering entity: {type.FullName} -> table {tableName}");
+                modelBuilder.Entity(type).ToTable(tableName);
+            });
+
+            // 剔除属性导航
+            //modelBuilder.Model.GetEntityTypes()
+            //    .Where(t => !t.ClrType.GetCustomAttributes(typeof(TableAttribute), true).Any() &&
+            //                !t.ClrType.GetCustomAttributes(typeof(FantasyTableAttribute), true).Any())
+            //    .ToList()
+            //    .ForEach(t => modelBuilder.Ignore(t.ClrType));
+
+            //foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+            //{
+            //    Log.Warning($"EFCore 全部注册的实体: {entityType.ClrType.FullName}");
+            //}
+
+            base.OnModelCreating(modelBuilder);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="assemblyManifest"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        public async FTask OnLoad(AssemblyManifest assemblyManifest)
+        {
+            await FTask.CompletedTask;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="assemblyManifest"></param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+
+        public async FTask OnUnload(AssemblyManifest assemblyManifest)
+        {
+            await FTask.CompletedTask;
+        }
+
+        /// <summary>
+        /// 释放
+        /// </summary>
+        public override void Dispose()
+        {
+            Mode = PreferSqlMode.EFCore;
+            pg = null;
+            base.Dispose();
+        }
+
+        /// <summary>
+        /// 异步释放
+        /// </summary>
+        public override async ValueTask DisposeAsync()
+        {
+            Mode = PreferSqlMode.EFCore;
+            pg = null;
+            await base.DisposeAsync();
+        }
+
+        /// <summary>
+        /// Sql 操作倾向模式选择, 默认选择是 EFCore, 倾向于使用 EFCore。
+        /// !! 需特别注意, 调用属于 IDbSession接口中的查询方法时， 使用Dapper模式, 会有一定的性能提升, 但这样就导致默认不会被 EFCore 框架自动跟踪属性变化了 !!
+        /// </summary>
+        public PreferSqlMode Mode { get; set; } = PreferSqlMode.EFCore;    
+     
+        #region Table
+
+        /// <summary>
+        /// PgSQL中表名即类型名, 如果通过 OnModelCreating 配置了指定表名, 才需用自定义名。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <returns>表名。</returns>
+        private string GetTableName<T>(string table = null) where T : Entity
+        {
+            return table ?? typeof(T).Name;
+        }
+
+        /// <summary>
+        /// 从表达式中获取列名。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="expression">字段表达式。</param>
+        /// <returns>列名。</returns>
+        private string GetColumnName<T>(Expression<Func<T, object>> expression)
+        {
+            // if (expression.Body is MemberExpression memberExpression)
+            // {
+            //     return memberExpression.Member.Name;
+            // }
+            // else if (expression.Body is UnaryExpression unaryExpression && unaryExpression.Operand is MemberExpression)
+            // {
+            //     return ((MemberExpression)unaryExpression.Operand).Member.Name;
+            // }
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// 将LINQ表达式转换为SQL WHERE子句。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="expression">LINQ表达式。</param>
+        /// <returns>SQL WHERE子句。</returns>
+        private string GetWhereClause<T>(Expression<Func<T, bool>> expression)
+        {
+            // 这里应该实现LINQ表达式到SQL的转换
+            // 为简化，返回一个占位符
+            return "1=1";
+        }
+
+        #endregion
+
+        #region Count
+
+        ///// <summary>
+        ///// 统计指定表中的总行数。
+        ///// </summary>
+        ///// <typeparam name="T">实体类型。</typeparam>
+        ///// <param name="table">表名称，可选。如果未指定，将使用实体类型的名称。</param>
+        ///// <param name="dbContext">上下文，可选。</param>
+        ///// <returns>总行数。</returns>
+        //public async FTask<long> Count<T>(string table = null,DbContext dbContext = null) where T : Entity
+        //{
+        //    var tableName = GetTableName<T>(table);
+        //    var connection = Handler.CreateConnection();
+        //    try
+        //    {
+        //        await connection.OpenAsync(); 
+        //        using (var cmd = connection.CreateCommand())
+        //        {
+        //            tableName = tableName.Replace("\"", "\"\"");
+        //            cmd.CommandText = $"SELECT COUNT(*) FROM \"{tableName}\"";
+        //            var result = await cmd.ExecuteScalarAsync();
+        //            return Convert.ToInt64(result);
+        //        }
+        //    }
+        //    finally
+        //    {
+        //        await connection.CloseAsync();
+        //    }
+        //}
+
+        /// <summary>
+        /// 自行执行一句原生SQL语句
+        /// </summary>
+        /// <param name="sql"></param>
+        /// <returns></returns>
+        private async FTask<object?> ExecuteRawSqlOnceDirectly(string sql) {
+
+            var connection = await GetOpenedConnection();//确保开启连接
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = sql;
+            return await cmd.ExecuteScalarAsync();
+        }
+
+        /// <summary>
+        /// 获取数据库连接, 并确保连接已打开。
+        /// </summary>
+        /// <returns></returns>
+        public async FTask<DbConnection> GetOpenedConnection() {
+            var _connection = Database.GetDbConnection();
+            if (_connection.State != ConnectionState.Open)
+                await _connection.OpenAsync();
+            return _connection;
+        }
+
+        /// <summary>
+        /// 统计指定表中的总行数。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="table">表名称，可选。如果未指定，将使用实体类型的名称。</param>
+        /// <returns>总行数。</returns>
+        public async FTask<long> Count<T>(string table = null) where T : Entity
+        {
+            var tableName = GetTableName<T>(table);                     
+
+            string sql = $"SELECT COUNT(*) FROM \"{tableName}\"";
+
+            switch (Mode)
+            {
+                case PreferSqlMode.EFCore:
+                    {
+                        return await Database.SqlQueryRaw<long>(sql).FirstOrDefaultAsync();
+                    }
+                default:
+                    {
+                        var result = ExecuteRawSqlOnceDirectly(sql);
+                        return Convert.ToInt64(result);
+                    }
+            }
+        }
+
+        /// <summary>
+        /// 统计指定表中满足条件的行数量。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="filter">用于筛选行的条件。</param>
+        /// <param name="table">表名称，可选。如果未指定，将使用实体类型的名称。</param>
+        /// <returns>满足条件的行数量。</returns>
+        public async FTask<long> Count<T>(Expression<Func<T, bool>> filter, string table = null) where T : Entity
+        {
+            return await Set<T>().CountAsync(filter);
+        }
+
+        /// <summary>
+        /// 快速估算表行数, 适合估算大表
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="table"></param>
+        /// <returns></returns>
+        public async FTask<long> FastCount<T>(string table = null) where T : Entity
+        {
+            var tableName = GetTableName<T>(table); 
+            var sql = $"SELECT reltuples::bigint FROM pg_class WHERE relname = '{tableName}'";
+
+            switch (Mode)
+            {
+                case PreferSqlMode.EFCore:
+                    {
+                        var result = await Database.SqlQueryRaw<long>(sql).FirstOrDefaultAsync();
+                        return result;
+                    }
+                default:
+                    {
+                        var result = await ExecuteRawSqlOnceDirectly(sql);
+                        return Convert.ToInt64(result);
+                    }
+            }
+        }
+
+
+        #endregion
+
+        #region Exist
+
+        /// <summary>
+        /// 判断指定表中是否存在行。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="table">表名称，可选。如果未指定，将使用实体类型的名称。</param>
+        /// <returns>如果存在行则返回 true，否则返回 false。</returns>
+        public async FTask<bool> Exist<T>(string table = null) where T : Entity
+        {
+            // return await Count<T>(table) > 0;
+            await FTask.CompletedTask;
+            return false;
+        }
+
+        /// <summary>
+        /// 判断指定表中是否存在满足条件的行。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="filter">用于筛选行的条件。</param>
+        /// <param name="table">表名称，可选。如果未指定，将使用实体类型的名称。</param>
+        /// <returns>如果存在满足条件的行则返回 true，否则返回 false。</returns>
+        public async FTask<bool> Exist<T>(Expression<Func<T, bool>> filter, string table = null) where T : Entity
+        {
+            // return await Count(filter, table) > 0;
+            await FTask.CompletedTask;
+            return false;
+        }
+
+        #endregion
+
+        #region Query
+
+        /// <summary>
+        /// 在不加数据库锁定的情况下，查询指定 ID 的行。
+        /// </summary>
+        /// <typeparam name="T">文档实体类型。</typeparam>
+        /// <param name="id">要查询的行 ID。</param>
+        /// <param name="isDeserialize">是否在查询后反序列化,执行反序列化后会自动将实体注册到框架系统中，并且能正常使用组件相关功能。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>查询到的行。</returns>
+        public async FTask<T> QueryNotLock<T>(long id, bool isDeserialize = false, string table = null) where T : Entity
+        {
+            // var tableName = GetTableName<T>(table);
+            // 
+            // using (await _dataBaseLock.Wait(id))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         cmd.CommandText = $"SELECT * FROM \"{tableName}\" WHERE \"Id\" = @Id";
+            //         cmd.Parameters.AddWithValue("Id", id);
+            //         using (var reader = await cmd.ExecuteReaderAsync())
+            //         {
+            //             if (await reader.ReadAsync())
+            //             {
+            //                 var bsonDocument = GetBsonDocumentFromReader(reader);
+            //                 var entity = _serializer.Deserialize<T>(bsonDocument);
+            //                 
+            //                 if (isDeserialize && entity != null)
+            //                 {
+            //                     entity.Deserialize(_scene);
+            //                 }
+            //                 
+            //                 await _connection.CloseAsync();
+            //                 return entity;
+            //             }
+            //         }
+            //     }
+            //     await _connection.CloseAsync();
+            //     return null;
+            // }
+            await FTask.CompletedTask;
+            return null;
+        }
+
+        /// <summary>
+        /// 查询指定 ID 的行，并加数据库锁定以确保数据一致性。
+        /// </summary>
+        /// <typeparam name="T">文档实体类型。</typeparam>
+        /// <param name="id">要查询的行 ID。</param>
+        /// <param name="isDeserialize">是否在查询后反序列化,执行反序列化后会自动将实体注册到框架系统中，并且能正常使用组件相关功能。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>查询到的行。</returns>
+        public async FTask<T> Query<T>(long id, bool isDeserialize = false, string table = null) where T : Entity
+        {
+            // var tableName = GetTableName<T>(table);
+            // 
+            // using (await _dataBaseLock.Wait(id))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         cmd.CommandText = $"SELECT * FROM \"{tableName}\" WHERE \"Id\" = @Id";
+            //         cmd.Parameters.AddWithValue("Id", id);
+            //         using (var reader = await cmd.ExecuteReaderAsync())
+            //         {
+            //             if (await reader.ReadAsync())
+            //             {
+            //                 var bsonDocument = GetBsonDocumentFromReader(reader);
+            //                 var entity = _serializer.Deserialize<T>(bsonDocument);
+            //                 
+            //                 if (isDeserialize && entity != null)
+            //                 {
+            //                     entity.Deserialize(_scene);
+            //                 }
+            //                 
+            //                 await _connection.CloseAsync();
+            //                 return entity;
+            //             }
+            //         }
+            //     }
+            //     await _connection.CloseAsync();
+            //     return null;
+            // }
+            await FTask.CompletedTask;
+            return null;
+        }
+
+        /// <summary>
+        /// 通过分页查询并返回满足条件的行数量和日期列表（不加锁）。
+        /// </summary>
+        /// <typeparam name="T">文档实体类型。</typeparam>
+        /// <param name="filter">查询过滤条件。</param>
+        /// <param name="pageIndex">页码。</param>
+        /// <param name="pageSize">每页大小。</param>
+        /// <param name="isDeserialize">是否在查询后反序列化,执行反序列化后会自动将实体注册到框架系统中，并且能正常使用组件相关功能。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>满足条件的行数量和日期列表。</returns>
+        public async FTask<(int count, List<T> dates)> QueryCountAndDatesByPage<T>(Expression<Func<T, bool>> filter, int pageIndex, int pageSize, bool isDeserialize = false, string table = null) where T : Entity
+        {
+            // using (await _dataBaseLock.Wait(RandomHelper.RandInt64() % DefaultTaskSize))
+            // {
+            //     var count = await Count(filter);
+            //     var dates = await QueryByPage(filter, pageIndex, pageSize, isDeserialize, table);
+            //     return ((int)count, dates);
+            // }
+            await FTask.CompletedTask;
+            return (0, new List<T>());
+        }
+
+        /// <summary>
+        /// 通过分页查询并返回满足条件的行数量和日期列表（加锁）。
+        /// </summary>
+        /// <typeparam name="T">文档实体类型。</typeparam>
+        /// <param name="filter">查询过滤条件。</param>
+        /// <param name="pageIndex">页码。</param>
+        /// <param name="pageSize">每页大小。</param>
+        /// <param name="cols">要查询的列名称数组。</param>
+        /// <param name="isDeserialize">是否在查询后反序列化,执行反序列化后会自动将实体注册到框架系统中，并且能正常使用组件相关功能。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>满足条件的行数量和日期列表。</returns>
+        public async FTask<(int count, List<T> dates)> QueryCountAndDatesByPage<T>(Expression<Func<T, bool>> filter, int pageIndex, int pageSize, string[] cols, bool isDeserialize = false, string table = null) where T : Entity
+        {
+            // using (await _dataBaseLock.Wait(RandomHelper.RandInt64() % DefaultTaskSize))
+            // {
+            //     var count = await Count(filter);
+            //     var dates = await QueryByPage(filter, pageIndex, pageSize, cols, isDeserialize, table);
+            //     return ((int)count, dates);
+            // }
+            await FTask.CompletedTask;
+            return (0, new List<T>());
+        }
+
+        /// <summary>
+        /// 通过分页查询并返回满足条件的行列表（不加锁）。
+        /// </summary>
+        /// <typeparam name="T">文档实体类型。</typeparam>
+        /// <param name="filter">查询过滤条件。</param>
+        /// <param name="pageIndex">页码。</param>
+        /// <param name="pageSize">每页大小。</param>
+        /// <param name="isDeserialize">是否在查询后反序列化,执行反序列化后会自动将实体注册到框架系统中，并且能正常使用组件相关功能。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>满足条件的行列表。</returns>
+        public async FTask<List<T>> QueryByPage<T>(Expression<Func<T, bool>> filter, int pageIndex, int pageSize, bool isDeserialize = false, string table = null) where T : Entity
+        {
+            // var tableName = GetTableName<T>(table);
+            // var whereClause = GetWhereClause(filter);
+            // 
+            // using (await _dataBaseLock.Wait(RandomHelper.RandInt64() % DefaultTaskSize))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         cmd.CommandText = $"SELECT * FROM \"{tableName}\" WHERE {whereClause} LIMIT {pageSize} OFFSET {(pageIndex - 1) * pageSize}";
+            //         var list = new List<T>();
+            //         using (var reader = await cmd.ExecuteReaderAsync())
+            //         {
+            //             while (await reader.ReadAsync())
+            //             {
+            //                 var bsonDocument = GetBsonDocumentFromReader(reader);
+            //                 var entity = _serializer.Deserialize<T>(bsonDocument);
+            //                 list.Add(entity);
+            //             }
+            //         }
+            //         
+            //         if (isDeserialize && list.Count > 0)
+            //         {
+            //             foreach (var entity in list)
+            //             {
+            //                 entity.Deserialize(_scene);
+            //             }
+            //         }
+            //         
+            //         await _connection.CloseAsync();
+            //         return list;
+            //     }
+            // }
+            await FTask.CompletedTask;
+            return new List<T>();
+        }
+
+        /// <summary>
+        /// 通过分页查询并返回满足条件的行列表（加锁）。
+        /// </summary>
+        /// <typeparam name="T">文档实体类型。</typeparam>
+        /// <param name="filter">查询过滤条件。</param>
+        /// <param name="pageIndex">页码。</param>
+        /// <param name="pageSize">每页大小。</param>
+        /// <param name="cols">要查询的列名称数组。</param>
+        /// <param name="isDeserialize">是否在查询后反序列化,执行反序列化后会自动将实体注册到框架系统中，并且能正常使用组件相关功能。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>满足条件的行列表。</returns>
+        public async FTask<List<T>> QueryByPage<T>(Expression<Func<T, bool>> filter, int pageIndex, int pageSize, string[] cols, bool isDeserialize = false, string table = null) where T : Entity
+        {
+            // var tableName = GetTableName<T>(table);
+            // var whereClause = GetWhereClause(filter);
+            // var columns = cols != null && cols.Length > 0 ? string.Join(", ", cols.Select(c => $"\"{c}\"")) : "*";
+            // 
+            // using (await _dataBaseLock.Wait(RandomHelper.RandInt64() % DefaultTaskSize))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         cmd.CommandText = $"SELECT {columns} FROM \"{tableName}\" WHERE {whereClause} LIMIT {pageSize} OFFSET {(pageIndex - 1) * pageSize}";
+            //         var list = new List<T>();
+            //         using (var reader = await cmd.ExecuteReaderAsync())
+            //         {
+            //             while (await reader.ReadAsync())
+            //             {
+            //                 var bsonDocument = GetBsonDocumentFromReader(reader);
+            //                 var entity = _serializer.Deserialize<T>(bsonDocument);
+            //                 list.Add(entity);
+            //             }
+            //         }
+            //         
+            //         if (isDeserialize && list.Count > 0)
+            //         {
+            //             foreach (var entity in list)
+            //             {
+            //                 entity.Deserialize(_scene);
+            //             }
+            //         }
+            //         
+            //         await _connection.CloseAsync();
+            //         return list;
+            //     }
+            // }
+            await FTask.CompletedTask;
+            return new List<T>();
+        }
+
+        /// <summary>
+        /// 通过分页查询并返回满足条件的行列表，并按指定表达式进行排序（加锁）。
+        /// </summary>
+        /// <typeparam name="T">文档实体类型。</typeparam>
+        /// <param name="filter">查询过滤条件。</param>
+        /// <param name="pageIndex">页码。</param>
+        /// <param name="pageSize">每页大小。</param>
+        /// <param name="orderByExpression">排序表达式。</param>
+        /// <param name="isAsc">是否升序排序。</param>
+        /// <param name="isDeserialize">是否在查询后反序列化,执行反序列化后会自动将实体注册到框架系统中，并且能正常使用组件相关功能。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>满足条件的行列表。</returns>
+        public async FTask<List<T>> QueryByPageOrderBy<T>(Expression<Func<T, bool>> filter, int pageIndex, int pageSize, Expression<Func<T, object>> orderByExpression, bool isAsc = true, bool isDeserialize = false, string table = null) where T : Entity
+        {
+            // var tableName = GetTableName<T>(table);
+            // var whereClause = GetWhereClause(filter);
+            // var orderByColumn = GetColumnName(orderByExpression);
+            // var orderDirection = isAsc ? "ASC" : "DESC";
+            // 
+            // using (await _dataBaseLock.Wait(RandomHelper.RandInt64() % DefaultTaskSize))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         cmd.CommandText = $"SELECT * FROM \"{tableName}\" WHERE {whereClause} ORDER BY \"{orderByColumn}\" {orderDirection} LIMIT {pageSize} OFFSET {(pageIndex - 1) * pageSize}";
+            //         var list = new List<T>();
+            //         using (var reader = await cmd.ExecuteReaderAsync())
+            //         {
+            //             while (await reader.ReadAsync())
+            //             {
+            //                 var bsonDocument = GetBsonDocumentFromReader(reader);
+            //                 var entity = _serializer.Deserialize<T>(bsonDocument);
+            //                 list.Add(entity);
+            //             }
+            //         }
+            //         
+            //         if (isDeserialize && list.Count > 0)
+            //         {
+            //             foreach (var entity in list)
+            //             {
+            //                 entity.Deserialize(_scene);
+            //             }
+            //         }
+            //         
+            //         await _connection.CloseAsync();
+            //         return list;
+            //     }
+            // }
+            await FTask.CompletedTask;
+            return new List<T>();
+        }
+
+        /// <summary>
+        /// 通过指定过滤条件查询并返回满足条件的第一个行（加锁）。
+        /// </summary>
+        /// <typeparam name="T">文档实体类型。</typeparam>
+        /// <param name="filter">查询过滤条件。</param>
+        /// <param name="isDeserialize">是否在查询后反序列化,执行反序列化后会自动将实体注册到框架系统中，并且能正常使用组件相关功能。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>满足条件的第一个行，如果未找到则为 null。</returns>
+        public async FTask<T?> First<T>(Expression<Func<T, bool>> filter, bool isDeserialize = false, string table = null) where T : Entity
+        {
+            // var tableName = GetTableName<T>(table);
+            // var whereClause = GetWhereClause(filter);
+            // 
+            // using (await _dataBaseLock.Wait(RandomHelper.RandInt64() % DefaultTaskSize))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         cmd.CommandText = $"SELECT * FROM \"{tableName}\" WHERE {whereClause} LIMIT 1";
+            //         using (var reader = await cmd.ExecuteReaderAsync())
+            //         {
+            //             if (await reader.ReadAsync())
+            //             {
+            //                 var bsonDocument = GetBsonDocumentFromReader(reader);
+            //                 var entity = _serializer.Deserialize<T>(bsonDocument);
+            //                 
+            //                 if (isDeserialize && entity != null)
+            //                 {
+            //                     entity.Deserialize(_scene);
+            //                 }
+            //                 
+            //                 await _connection.CloseAsync();
+            //                 return entity;
+            //             }
+            //         }
+            //     }
+            //     await _connection.CloseAsync();
+            //     return null;
+            // }
+            await FTask.CompletedTask;
+            return null;
+        }
+
+        /// <summary>
+        /// 通过指定 JSON 格式查询并返回满足条件的第一个行（加锁）。
+        /// </summary>
+        /// <typeparam name="T">文档实体类型。</typeparam>
+        /// <param name="json">JSON 查询条件。</param>
+        /// <param name="cols">要查询的列名称数组。</param>
+        /// <param name="isDeserialize">是否在查询后反序列化,执行反序列化后会自动将实体注册到框架系统中，并且能正常使用组件相关功能。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>满足条件的第一个行。</returns>
+        public async FTask<T> First<T>(string json, string[] cols, bool isDeserialize = false, string table = null) where T : Entity
+        {
+            // var tableName = GetTableName<T>(table);
+            // var columns = cols != null && cols.Length > 0 ? string.Join(", ", cols.Select(c => $"\"{c}\"")) : "*";
+            // 
+            // using (await _dataBaseLock.Wait(RandomHelper.RandInt64() % DefaultTaskSize))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         // 这里需要将JSON条件转换为SQL WHERE子句
+            //         cmd.CommandText = $"SELECT {columns} FROM \"{tableName}\" WHERE {ConvertJsonToWhereClause(json)} LIMIT 1";
+            //         using (var reader = await cmd.ExecuteReaderAsync())
+            //         {
+            //             if (await reader.ReadAsync())
+            //             {
+            //                 var bsonDocument = GetBsonDocumentFromReader(reader);
+            //                 var entity = _serializer.Deserialize<T>(bsonDocument);
+            //                 
+            //                 if (isDeserialize && entity != null)
+            //                 {
+            //                     entity.Deserialize(_scene);
+            //                 }
+            //                 
+            //                 await _connection.CloseAsync();
+            //                 return entity;
+            //             }
+            //         }
+            //     }
+            //     await _connection.CloseAsync();
+            //     return null;
+            // }
+            await FTask.CompletedTask;
+            return null;
+        }
+
+        /// <summary>
+        /// 通过指定过滤条件查询并返回满足条件的行列表，并按指定表达式进行排序（加锁）。
+        /// </summary>
+        /// <typeparam name="T">文档实体类型。</typeparam>
+        /// <param name="filter">查询过滤条件。</param>
+        /// <param name="orderByExpression">排序表达式。</param>
+        /// <param name="isAsc">是否升序排序。</param>
+        /// <param name="isDeserialize">是否在查询后反序列化,执行反序列化后会自动将实体注册到框架系统中，并且能正常使用组件相关功能。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>满足条件的行列表。</returns>
+        public async FTask<List<T>> QueryOrderBy<T>(Expression<Func<T, bool>> filter, Expression<Func<T, object>> orderByExpression, bool isAsc = true, bool isDeserialize = false, string table = null) where T : Entity
+        {
+            // var tableName = GetTableName<T>(table);
+            // var whereClause = GetWhereClause(filter);
+            // var orderByColumn = GetColumnName(orderByExpression);
+            // var orderDirection = isAsc ? "ASC" : "DESC";
+            // 
+            // using (await _dataBaseLock.Wait(RandomHelper.RandInt64() % DefaultTaskSize))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         cmd.CommandText = $"SELECT * FROM \"{tableName}\" WHERE {whereClause} ORDER BY \"{orderByColumn}\" {orderDirection}";
+            //         var list = new List<T>();
+            //         using (var reader = await cmd.ExecuteReaderAsync())
+            //         {
+            //             while (await reader.ReadAsync())
+            //             {
+            //                 var bsonDocument = GetBsonDocumentFromReader(reader);
+            //                 var entity = _serializer.Deserialize<T>(bsonDocument);
+            //                 list.Add(entity);
+            //             }
+            //         }
+            //         
+            //         if (isDeserialize && list.Count > 0)
+            //         {
+            //             foreach (var entity in list)
+            //             {
+            //                 entity.Deserialize(_scene);
+            //             }
+            //         }
+            //         
+            //         await _connection.CloseAsync();
+            //         return list;
+            //     }
+            // }
+            await FTask.CompletedTask;
+            return new List<T>();
+        }
+
+        /// <summary>
+        /// 通过指定过滤条件查询并返回满足条件的行列表（加锁）。
+        /// </summary>
+        /// <typeparam name="T">文档实体类型。</typeparam>
+        /// <param name="filter">查询过滤条件。</param>
+        /// <param name="isDeserialize">是否在查询后反序列化,执行反序列化后会自动将实体注册到框架系统中，并且能正常使用组件相关功能。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>满足条件的行列表。</returns>
+        public async FTask<List<T>> Query<T>(Expression<Func<T, bool>> filter, bool isDeserialize = false, string table = null) where T : Entity
+        {
+            // var tableName = GetTableName<T>(table);
+            // var whereClause = GetWhereClause(filter);
+            // 
+            // using (await _dataBaseLock.Wait(RandomHelper.RandInt64() % DefaultTaskSize))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         cmd.CommandText = $"SELECT * FROM \"{tableName}\" WHERE {whereClause}";
+            //         var list = new List<T>();
+            //         using (var reader = await cmd.ExecuteReaderAsync())
+            //         {
+            //             while (await reader.ReadAsync())
+            //             {
+            //                 var bsonDocument = GetBsonDocumentFromReader(reader);
+            //                 var entity = _serializer.Deserialize<T>(bsonDocument);
+            //                 list.Add(entity);
+            //             }
+            //         }
+            //         
+            //         if (isDeserialize && list.Count > 0)
+            //         {
+            //             foreach (var entity in list)
+            //             {
+            //                 entity.Deserialize(_scene);
+            //             }
+            //         }
+            //         
+            //         await _connection.CloseAsync();
+            //         return list;
+            //     }
+            // }
+            await FTask.CompletedTask;
+            return new List<T>();
+        }
+
+        /// <summary>
+        /// 根据指定 ID 加锁查询多个表中的行。
+        /// </summary>
+        /// <param name="id">行 ID。</param>
+        /// <param name="tableNames">要查询的表名称列表。</param>
+        /// <param name="result">查询结果存储列表。</param>
+        /// <param name="isDeserialize">是否在查询后反序列化,执行反序列化后会自动将实体注册到框架系统中，并且能正常使用组件相关功能。</param>
+        public async FTask Query(long id, List<string>? tableNames, List<Entity> result, bool isDeserialize = false)
+        {
+            // if (tableNames == null || tableNames.Count == 0)
+            // {
+            //     return;
+            // }
+            // 
+            // using (await _dataBaseLock.Wait(id))
+            // {
+            //     await _connection.OpenAsync();
+            //     foreach (var tableName in tableNames)
+            //     {
+            //         using (var cmd = _connection.CreateCommand())
+            //         {
+            //             cmd.CommandText = $"SELECT * FROM \"{tableName}\" WHERE \"Id\" = @Id";
+            //             cmd.Parameters.AddWithValue("Id", id);
+            //             using (var reader = await cmd.ExecuteReaderAsync())
+            //             {
+            //                 if (await reader.ReadAsync())
+            //                 {
+            //                     var bsonDocument = GetBsonDocumentFromReader(reader);
+            //                     var entityType = Type.GetType($"Fantasy.Entities.{tableName}, Fantasy");
+            //                     if (entityType != null && typeof(Entity).IsAssignableFrom(entityType))
+            //                     {
+            //                         var entity = _serializer.Deserialize(entityType, bsonDocument) as Entity;
+            //                         if (isDeserialize && entity != null)
+            //                         {
+            //                             entity.Deserialize(_scene);
+            //                         }
+            //                         result.Add(entity);
+            //                     }
+            //                 }
+            //             }
+            //         }
+            //     }
+            //     await _connection.CloseAsync();
+            // }
+            await FTask.CompletedTask;
+        }
+
+        /// <summary>
+        /// 根据指定的 JSON 查询条件查询并返回满足条件的行列表（加锁）。
+        /// </summary>
+        /// <typeparam name="T">文档实体类型。</typeparam>
+        /// <param name="json">JSON 查询条件。</param>
+        /// <param name="isDeserialize">是否在查询后反序列化,执行反序列化后会自动将实体注册到框架系统中，并且能正常使用组件相关功能。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>满足条件的行列表。</returns>
+        public async FTask<List<T>> QueryJson<T>(string json, bool isDeserialize = false, string table = null) where T : Entity
+        {
+            // var tableName = GetTableName<T>(table);
+            // 
+            // using (await _dataBaseLock.Wait(RandomHelper.RandInt64() % DefaultTaskSize))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         // 这里需要将JSON条件转换为SQL WHERE子句
+            //         cmd.CommandText = $"SELECT * FROM \"{tableName}\" WHERE {ConvertJsonToWhereClause(json)}";
+            //         var list = new List<T>();
+            //         using (var reader = await cmd.ExecuteReaderAsync())
+            //         {
+            //             while (await reader.ReadAsync())
+            //             {
+            //                 var bsonDocument = GetBsonDocumentFromReader(reader);
+            //                 var entity = _serializer.Deserialize<T>(bsonDocument);
+            //                 list.Add(entity);
+            //             }
+            //         }
+            //         
+            //         if (isDeserialize && list.Count > 0)
+            //         {
+            //             foreach (var entity in list)
+            //             {
+            //                 entity.Deserialize(_scene);
+            //             }
+            //         }
+            //         
+            //         await _connection.CloseAsync();
+            //         return list;
+            //     }
+            // }
+            await FTask.CompletedTask;
+            return new List<T>();
+        }
+
+        /// <summary>
+        /// 根据指定的 JSON 查询条件查询并返回满足条件的行列表，并选择指定的列（加锁）。
+        /// </summary>
+        /// <typeparam name="T">文档实体类型。</typeparam>
+        /// <param name="json">JSON 查询条件。</param>
+        /// <param name="cols">要查询的列名称数组。</param>
+        /// <param name="isDeserialize">是否在查询后反序列化,执行反序列化后会自动将实体注册到框架系统中，并且能正常使用组件相关功能。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>满足条件的行列表。</returns>
+        public async FTask<List<T>> QueryJson<T>(string json, string[] cols, bool isDeserialize = false, string table = null) where T : Entity
+        {
+            // var tableName = GetTableName<T>(table);
+            // var columns = cols != null && cols.Length > 0 ? string.Join(", ", cols.Select(c => $"\"{c}\"")) : "*";
+            // 
+            // using (await _dataBaseLock.Wait(RandomHelper.RandInt64() % DefaultTaskSize))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         // 这里需要将JSON条件转换为SQL WHERE子句
+            //         cmd.CommandText = $"SELECT {columns} FROM \"{tableName}\" WHERE {ConvertJsonToWhereClause(json)}";
+            //         var list = new List<T>();
+            //         using (var reader = await cmd.ExecuteReaderAsync())
+            //         {
+            //             while (await reader.ReadAsync())
+            //             {
+            //                 var bsonDocument = GetBsonDocumentFromReader(reader);
+            //                 var entity = _serializer.Deserialize<T>(bsonDocument);
+            //                 list.Add(entity);
+            //             }
+            //         }
+            //         
+            //         if (isDeserialize && list.Count > 0)
+            //         {
+            //             foreach (var entity in list)
+            //             {
+            //                 entity.Deserialize(_scene);
+            //             }
+            //         }
+            //         
+            //         await _connection.CloseAsync();
+            //         return list;
+            //     }
+            // }
+            await FTask.CompletedTask;
+            return new List<T>();
+        }
+
+        /// <summary>
+        /// 根据指定的 JSON 查询条件和任务 ID 查询并返回满足条件的行列表（加锁）。
+        /// </summary>
+        /// <typeparam name="T">文档实体类型。</typeparam>
+        /// <param name="taskId">任务 ID。</param>
+        /// <param name="json">JSON 查询条件。</param>
+        /// <param name="isDeserialize">是否在查询后反序列化,执行反序列化后会自动将实体注册到框架系统中，并且能正常使用组件相关功能。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>满足条件的行列表。</returns>
+        public async FTask<List<T>> QueryJson<T>(long taskId, string json, bool isDeserialize = false, string table = null) where T : Entity
+        {
+            // var tableName = GetTableName<T>(table);
+            // 
+            // using (await _dataBaseLock.Wait(taskId))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         // 这里需要将JSON条件转换为SQL WHERE子句
+            //         cmd.CommandText = $"SELECT * FROM \"{tableName}\" WHERE {ConvertJsonToWhereClause(json)}";
+            //         var list = new List<T>();
+            //         using (var reader = await cmd.ExecuteReaderAsync())
+            //         {
+            //             while (await reader.ReadAsync())
+            //             {
+            //                 var bsonDocument = GetBsonDocumentFromReader(reader);
+            //                 var entity = _serializer.Deserialize<T>(bsonDocument);
+            //                 list.Add(entity);
+            //             }
+            //         }
+            //         
+            //         if (isDeserialize && list.Count > 0)
+            //         {
+            //             foreach (var entity in list)
+            //             {
+            //                 entity.Deserialize(_scene);
+            //             }
+            //         }
+            //         
+            //         await _connection.CloseAsync();
+            //         return list;
+            //     }
+            // }
+            await FTask.CompletedTask;
+            return new List<T>();
+        }
+
+        /// <summary>
+        /// 根据指定过滤条件查询并返回满足条件的行列表，选择指定的列（加锁）。
+        /// </summary>
+        /// <typeparam name="T">文档实体类型。</typeparam>
+        /// <param name="filter">查询过滤条件。</param>
+        /// <param name="cols">要查询的列名称数组。</param>
+        /// <param name="isDeserialize">是否在查询后反序列化,执行反序列化后会自动将实体注册到框架系统中，并且能正常使用组件相关功能。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>满足条件的行列表。</returns>
+        public async FTask<List<T>> Query<T>(Expression<Func<T, bool>> filter, string[] cols, bool isDeserialize = false, string table = null) where T : Entity
+        {
+            // var tableName = GetTableName<T>(table);
+            // var whereClause = GetWhereClause(filter);
+            // var columns = cols != null && cols.Length > 0 ? string.Join(", ", cols.Select(c => $"\"{c}\"")) : "*";
+            // 
+            // using (await _dataBaseLock.Wait(RandomHelper.RandInt64() % DefaultTaskSize))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         cmd.CommandText = $"SELECT {columns} FROM \"{tableName}\" WHERE {whereClause}";
+            //         var list = new List<T>();
+            //         using (var reader = await cmd.ExecuteReaderAsync())
+            //         {
+            //             while (await reader.ReadAsync())
+            //             {
+            //                 var bsonDocument = GetBsonDocumentFromReader(reader);
+            //                 var entity = _serializer.Deserialize<T>(bsonDocument);
+            //                 list.Add(entity);
+            //             }
+            //         }
+            //         
+            //         if (isDeserialize && list.Count > 0)
+            //         {
+            //             foreach (var entity in list)
+            //             {
+            //                 entity.Deserialize(_scene);
+            //             }
+            //         }
+            //         
+            //         await _connection.CloseAsync();
+            //         return list;
+            //     }
+            // }
+            await FTask.CompletedTask;
+            return new List<T>();
+        }
+
+        /// <summary>
+        /// 根据指定过滤条件查询并返回满足条件的行列表，选择指定的列（加锁）。
+        /// </summary>
+        /// <param name="filter">文档实体类型。</param>
+        /// <param name="cols">查询过滤条件。</param>
+        /// <param name="isDeserialize">要查询的列名称数组。</param>
+        /// <param name="table">是否在查询后反序列化,执行反序列化后会自动将实体注册到框架系统中，并且能正常使用组件相关功能。</param>
+        /// <typeparam name="T">表名称。</typeparam>
+        /// <returns></returns>
+        public async FTask<List<T>> Query<T>(Expression<Func<T, bool>> filter, Expression<Func<T, object>>[] cols, bool isDeserialize = false, string table = null) where T : Entity
+        {
+            // var tableName = GetTableName<T>(table);
+            // var whereClause = GetWhereClause(filter);
+            // var columns = new List<string> { "\"Id\"" }; // 确保包含Id列
+            // 
+            // foreach (var col in cols)
+            // {
+            //     if (col.Body is MemberExpression memberExpression)
+            //     {
+            //         columns.Add($"\"{memberExpression.Member.Name}\"");
+            //     }
+            //     else if (col.Body is UnaryExpression unaryExpression && unaryExpression.Operand is MemberExpression)
+            //     {
+            //         columns.Add($"\"{((MemberExpression)unaryExpression.Operand).Member.Name}\"");
+            //     }
+            // }
+            // 
+            // var columnsStr = string.Join(", ", columns);
+            // 
+            // using (await _dataBaseLock.Wait(RandomHelper.RandInt64() % DefaultTaskSize))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         cmd.CommandText = $"SELECT {columnsStr} FROM \"{tableName}\" WHERE {whereClause}";
+            //         var list = new List<T>();
+            //         using (var reader = await cmd.ExecuteReaderAsync())
+            //         {
+            //             while (await reader.ReadAsync())
+            //             {
+            //                 var bsonDocument = GetBsonDocumentFromReader(reader);
+            //                 var entity = _serializer.Deserialize<T>(bsonDocument);
+            //                 list.Add(entity);
+            //             }
+            //         }
+            //         
+            //         if (isDeserialize && list.Count > 0)
+            //         {
+            //             foreach (var entity in list)
+            //             {
+            //                 entity.Deserialize(_scene);
+            //             }
+            //         }
+            //         
+            //         await _connection.CloseAsync();
+            //         return list;
+            //     }
+            // }
+            await FTask.CompletedTask;
+            return new List<T>();
+        }
+
+        #endregion
+
+        #region Save
+
+        /// <summary>
+        /// 保存实体对象到数据库（加锁）。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="transactionSession">事务会话对象。</param>
+        /// <param name="entity">要保存的实体对象。</param>
+        /// <param name="table">表名称。</param>
+        public async FTask Save<T>(object transactionSession, T? entity, string table = null) where T : Entity
+        {
+            // if (entity == null)
+            // {
+            //     Log.Error($"save entity is null: {typeof(T).Name}");
+            //     return;
+            // }
+            // 
+            // var clone = _serializer.Clone(entity);
+            // var tableName = GetTableName<T>(table);
+            // 
+            // using (await _dataBaseLock.Wait(clone.Id))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         cmd.Transaction = (NpgsqlTransaction)transactionSession;
+            //         var columns = GetColumnsForEntity(clone);
+            //         var values = GetValuesForEntity(clone);
+            //         
+            //         // 检查记录是否存在
+            //         cmd.CommandText = $"SELECT COUNT(*) FROM \"{tableName}\" WHERE \"Id\" = @Id";
+            //         cmd.Parameters.Clear();
+            //         cmd.Parameters.AddWithValue("Id", clone.Id);
+            //         var count = Convert.ToInt64(await cmd.ExecuteScalarAsync());
+            //         
+            //         if (count > 0)
+            //         {
+            //             // 更新
+            //             var setClause = string.Join(", ", columns.Select(c => $"\"{c}\" = @{c}"));
+            //             cmd.CommandText = $"UPDATE \"{tableName}\" SET {setClause} WHERE \"Id\" = @Id";
+            //             AddParametersForEntity(cmd, clone, columns);
+            //         }
+            //         else
+            //         {
+            //             // 插入
+            //             var columnList = string.Join(", ", columns.Select(c => $"\"{c}\""));
+            //             var valueList = string.Join(", ", columns.Select(c => $"@{c}"));
+            //             cmd.CommandText = $"INSERT INTO \"{tableName}\" ({columnList}) VALUES ({valueList})";
+            //             AddParametersForEntity(cmd, clone, columns);
+            //         }
+            //         
+            //         await cmd.ExecuteNonQueryAsync();
+            //         await _connection.CloseAsync();
+            //     }
+            // }
+            await FTask.CompletedTask;
+        }
+
+        /// <summary>
+        /// 保存实体对象到数据库（加锁）。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="entity">要保存的实体对象。</param>
+        /// <param name="table">表名称。</param>
+        public async FTask Save<T>(T? entity, string table = null) where T : Entity, new()
+        {
+            if (entity == null)
+            {
+                Log.Error($"save entity is null: {typeof(T).Name}");
+                return;
+            }
+
+            var tableName = GetTableName<T>(table);
+
+            using (await pg.FlowLock.Wait(entity.Id))
+            {
+                switch (Mode)
+                {
+                    case PreferSqlMode.EFCore:
+                        {
+                            Entry(entity).State = EntityState.Modified;
+                            await SaveChangesAsync();
+                            break;
+                        }
+                    case PreferSqlMode.Dapper:
+                        {
+                            var _connection =  await GetOpenedConnection();
+                            
+
+                            break;
+                        }
+                }              
+            }
+            await FTask.CompletedTask;
+        }
+
+        /// <summary>
+        /// 保存实体对象到数据库（加锁）。
+        /// </summary>
+        /// <param name="filter">保存的条件表达式。</param>
+        /// <param name="entity">实体类型。</param>
+        /// <param name="table">表名称。</param>
+        /// <typeparam name="T"></typeparam>
+        public async FTask Save<T>(Expression<Func<T, bool>> filter, T? entity, string table = null) where T : Entity, new()
+        {
+            // if (entity == null)
+            // {
+            //     Log.Error($"save entity is null: {typeof(T).Name}");
+            //     return;
+            // }
+            // 
+            // var clone = _serializer.Clone(entity);
+            // var tableName = GetTableName<T>(table);
+            // var whereClause = GetWhereClause(filter);
+            // 
+            // using (await _dataBaseLock.Wait(clone.Id))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         var columns = GetColumnsForEntity(clone);
+            //         var setClause = string.Join(", ", columns.Select(c => $"\"{c}\" = @{c}"));
+            //         
+            //         cmd.CommandText = $"UPDATE \"{tableName}\" SET {setClause} WHERE {whereClause}";
+            //         AddParametersForEntity(cmd, clone, columns);
+            //         
+            //         await cmd.ExecuteNonQueryAsync();
+            //         await _connection.CloseAsync();
+            //     }
+            // }
+            await FTask.CompletedTask;
+        }
+
+        /// <summary>
+        /// 保存多个实体对象到数据库（加锁）。
+        /// </summary>
+        /// <param name="id">行 ID。</param>
+        /// <param name="entities">要保存的实体对象列表。</param>
+        public async FTask Save(long id, List<Entity>? entities)
+        {
+            // if (entities == null || entities.Count == 0)
+            // {
+            //     Log.Error("save entity is null");
+            //     return;
+            // }
+            // 
+            // using var listPool = ListPool<Entity>.Create();
+            // 
+            // foreach (var entity in entities)
+            // {
+            //     listPool.Add(_serializer.Clone(entity)); 
+            // }
+            // 
+            // using (await _dataBaseLock.Wait(id))
+            // {
+            //     await _connection.OpenAsync();
+            //     foreach (var clone in listPool)
+            //     {
+            //         try
+            //         {
+            //             var tableName = clone.GetType().Name;
+            //             var columns = GetColumnsForEntity(clone);
+            //             
+            //             // 检查记录是否存在
+            //             using (var cmd = _connection.CreateCommand())
+            //             {
+            //                 cmd.CommandText = $"SELECT COUNT(*) FROM \"{tableName}\" WHERE \"Id\" = @Id";
+            //                 cmd.Parameters.Clear();
+            //                 cmd.Parameters.AddWithValue("Id", clone.Id);
+            //                 var count = Convert.ToInt64(await cmd.ExecuteScalarAsync());
+            //                 
+            //                 if (count > 0)
+            //                 {
+            //                     // 更新
+            //                     var setClause = string.Join(", ", columns.Select(c => $"\"{c}\" = @{c}"));
+            //                     cmd.CommandText = $"UPDATE \"{tableName}\" SET {setClause} WHERE \"Id\" = @Id";
+            //                     AddParametersForEntity(cmd, clone, columns);
+            //                 }
+            //                 else
+            //                 {
+            //                     // 插入
+            //                     var columnList = string.Join(", ", columns.Select(c => $"\"{c}\""));
+            //                     var valueList = string.Join(", ", columns.Select(c => $"@{c}"));
+            //                     cmd.CommandText = $"INSERT INTO \"{tableName}\" ({columnList}) VALUES ({valueList})";
+            //                     AddParametersForEntity(cmd, clone, columns);
+            //                 }
+            //                 
+            //                 await cmd.ExecuteNonQueryAsync();
+            //             }
+            //         }
+            //         catch (Exception e)
+            //         {
+            //             Log.Error($"Save List Entity Error: {clone.GetType().Name} {clone}\n{e}");
+            //         }
+            //     }
+            //     await _connection.CloseAsync();
+            // }
+            await FTask.CompletedTask;
+        }
+
+        #endregion
+
+        #region Insert
+
+        /// <summary>
+        /// 插入单个实体对象到数据库（加锁）。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="entity">要插入的实体对象。</param>
+        /// <param name="table">表名称。</param>
+        public async FTask Insert<T>(T? entity, string table = null) where T : Entity, new()
+        {
+            // if (entity == null)
+            // {
+            //     Log.Error($"insert entity is null: {typeof(T).Name}");
+            //     return;
+            // }
+            // 
+            // var clone = _serializer.Clone(entity);
+            // var tableName = GetTableName<T>(table);
+            // 
+            // using (await _dataBaseLock.Wait(entity.Id))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         var columns = GetColumnsForEntity(clone);
+            //         var columnList = string.Join(", ", columns.Select(c => $"\"{c}\""));
+            //         var valueList = string.Join(", ", columns.Select(c => $"@{c}"));
+            //         
+            //         cmd.CommandText = $"INSERT INTO \"{tableName}\" ({columnList}) VALUES ({valueList})";
+            //         AddParametersForEntity(cmd, clone, columns);
+            //         
+            //         await cmd.ExecuteNonQueryAsync();
+            //         await _connection.CloseAsync();
+            //     }
+            // }
+            await FTask.CompletedTask;
+        }
+
+        /// <summary>
+        /// 批量插入实体对象列表到数据库（加锁）。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="list">要插入的实体对象列表。</param>
+        /// <param name="table">表名称。</param>
+        public async FTask InsertBatch<T>(IEnumerable<T> list, string table = null) where T : Entity, new()
+        {
+            // var tableName = GetTableName<T>(table);
+            // 
+            // using (await _dataBaseLock.Wait(RandomHelper.RandInt64() % DefaultTaskSize))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         foreach (var entity in list)
+            //         {
+            //             var clone = _serializer.Clone(entity);
+            //             var columns = GetColumnsForEntity(clone);
+            //             var columnList = string.Join(", ", columns.Select(c => $"\"{c}\""));
+            //             var valueList = string.Join(", ", columns.Select(c => $"@{c}"));
+            //             
+            //             cmd.CommandText = $"INSERT INTO \"{tableName}\" ({columnList}) VALUES ({valueList})";
+            //             cmd.Parameters.Clear();
+            //             AddParametersForEntity(cmd, clone, columns);
+            //             
+            //             await cmd.ExecuteNonQueryAsync();
+            //         }
+            //         await _connection.CloseAsync();
+            //     }
+            // }
+            await FTask.CompletedTask;
+        }
+
+        /// <summary>
+        /// 批量插入实体对象列表到数据库（加锁）。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="transactionSession">事务会话对象。</param>
+        /// <param name="list">要插入的实体对象列表。</param>
+        /// <param name="table">表名称。</param>
+        public async FTask InsertBatch<T>(object transactionSession, IEnumerable<T> list, string table = null)
+            where T : Entity, new()
+        {
+            // var tableName = GetTableName<T>(table);
+            // 
+            // using (await _dataBaseLock.Wait(RandomHelper.RandInt64() % DefaultTaskSize))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         cmd.Transaction = (NpgsqlTransaction)transactionSession;
+            //         
+            //         foreach (var entity in list)
+            //         {
+            //             var clone = _serializer.Clone(entity);
+            //             var columns = GetColumnsForEntity(clone);
+            //             var columnList = string.Join(", ", columns.Select(c => $"\"{c}\""));
+            //             var valueList = string.Join(", ", columns.Select(c => $"@{c}"));
+            //             
+            //             cmd.CommandText = $"INSERT INTO \"{tableName}\" ({columnList}) VALUES ({valueList})";
+            //             cmd.Parameters.Clear();
+            //             AddParametersForEntity(cmd, clone, columns);
+            //             
+            //             await cmd.ExecuteNonQueryAsync();
+            //         }
+            //         await _connection.CloseAsync();
+            //     }
+            // }
+            await FTask.CompletedTask;
+        }
+
+        /// <summary>
+        /// 插入BsonDocument到数据库（加锁）。
+        /// </summary>
+        /// <param name="bsonDocument"></param>
+        /// <param name="taskId"></param>
+        /// <typeparam name="T"></typeparam>
+        public async Task Insert<T>(BsonDocument bsonDocument, long taskId) where T : Entity
+        {
+            // var tableName = GetTableName<T>();
+            // 
+            // using (await _dataBaseLock.Wait(taskId))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         var columns = bsonDocument.Names;
+            //         var columnList = string.Join(", ", columns.Select(c => $"\"{c}\""));
+            //         var valueList = string.Join(", ", columns.Select(c => $"@{c}"));
+            //         
+            //         cmd.CommandText = $"INSERT INTO \"{tableName}\" ({columnList}) VALUES ({valueList})";
+            //         foreach (var name in columns)
+            //         {
+            //             cmd.Parameters.AddWithValue(name, bsonDocument[name].RawValue);
+            //         }
+            //         
+            //         await cmd.ExecuteNonQueryAsync();
+            //         await _connection.CloseAsync();
+            //     }
+            // }
+            await FTask.CompletedTask;
+        }
+
+        #endregion
+
+        #region Remove
+
+        /// <summary>
+        /// 根据ID删除单个实体对象（加锁）。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="transactionSession">事务会话对象。</param>
+        /// <param name="id">要删除的实体的ID。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>删除的实体数量。</returns>
+        public async FTask<long> Remove<T>(object transactionSession, long id, string table = null)
+            where T : Entity, new()
+        {
+            // var tableName = GetTableName<T>(table);
+            // 
+            // using (await _dataBaseLock.Wait(id))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         cmd.Transaction = (NpgsqlTransaction)transactionSession;
+            //         cmd.CommandText = $"DELETE FROM \"{tableName}\" WHERE \"Id\" = @Id";
+            //         cmd.Parameters.AddWithValue("Id", id);
+            //         var result = await cmd.ExecuteNonQueryAsync();
+            //         await _connection.CloseAsync();
+            //         return result;
+            //     }
+            // }
+            await FTask.CompletedTask;
+            return 0;
+        }
+
+        /// <summary>
+        /// 根据ID删除单个实体对象（加锁）。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="id">要删除的实体的ID。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>删除的实体数量。</returns>
+        public async FTask<long> Remove<T>(long id, string table = null) where T : Entity, new()
+        {
+            // var tableName = GetTableName<T>(table);
+            // 
+            // using (await _dataBaseLock.Wait(id))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         cmd.CommandText = $"DELETE FROM \"{tableName}\" WHERE \"Id\" = @Id";
+            //         cmd.Parameters.AddWithValue("Id", id);
+            //         var result = await cmd.ExecuteNonQueryAsync();
+            //         await _connection.CloseAsync();
+            //         return result;
+            //     }
+            // }
+            await FTask.CompletedTask;
+            return 0;
+        }
+
+        /// <summary>
+        /// 根据ID和筛选条件删除多个实体对象（加锁）。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="coroutineLockQueueKey">异步锁Id。</param>
+        /// <param name="transactionSession">事务会话对象。</param>
+        /// <param name="filter">筛选条件。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>删除的实体数量。</returns>
+        public async FTask<long> Remove<T>(long coroutineLockQueueKey, object transactionSession,
+            Expression<Func<T, bool>> filter, string table = null) where T : Entity, new()
+        {
+            // var tableName = GetTableName<T>(table);
+            // var whereClause = GetWhereClause(filter);
+            // 
+            // using (await _dataBaseLock.Wait(coroutineLockQueueKey))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         cmd.Transaction = (NpgsqlTransaction)transactionSession;
+            //         cmd.CommandText = $"DELETE FROM \"{tableName}\" WHERE {whereClause}";
+            //         var result = await cmd.ExecuteNonQueryAsync();
+            //         await _connection.CloseAsync();
+            //         return result;
+            //     }
+            // }
+            await FTask.CompletedTask;
+            return 0;
+        }
+
+        /// <summary>
+        /// 根据ID和筛选条件删除多个实体对象（加锁）。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="coroutineLockQueueKey">异步锁Id。</param>
+        /// <param name="filter">筛选条件。</param>
+        /// <param name="table">表名称。</param>
+        /// <returns>删除的实体数量。</returns>
+        public async FTask<long> Remove<T>(long coroutineLockQueueKey, Expression<Func<T, bool>> filter,
+            string table = null) where T : Entity, new()
+        {
+            // var tableName = GetTableName<T>(table);
+            // var whereClause = GetWhereClause(filter);
+            // 
+            // using (await _dataBaseLock.Wait(coroutineLockQueueKey))
+            // {
+            //     await _connection.OpenAsync();
+            //     using (var cmd = _connection.CreateCommand())
+            //     {
+            //         cmd.CommandText = $"DELETE FROM \"{tableName}\" WHERE {whereClause}";
+            //         var result = await cmd.ExecuteNonQueryAsync();
+            //         await _connection.CloseAsync();
+            //         return result;
+            //     }
+            // }
+            await FTask.CompletedTask;
+            return 0;
+        }
+
+        #endregion
+
+        #region Utility
+
+        /// <summary>
+        /// ***************************** AI写的, 待人工检验 ********************************
+        /// 对满足条件的行中的某个数值字段进行求和操作。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="filter">用于筛选行的条件。</param>
+        /// <param name="sumExpression">要对其进行求和的字段表达式。</param>
+        /// <param name="table">表名称，可选。如果未指定，将使用实体类型的名称。</param>
+        /// <returns>满足条件的行中指定字段的求和结果。</returns>
+        public async FTask<long> Sum<T>(Expression<Func<T, bool>> filter, Expression<Func<T, object>> sumExpression, string? table = null) where T : Entity
+        {
+            //var tableName = table ?? typeof(T).Name.ToLowerInvariant();
+            //var columnName = GetColumnName(sumExpression);
+
+            //var (whereClause, parameters) = BuildSqlWhereClause(filter); //这里调用之后进行了复杂的构建
+
+            //await using var conn = await Handler.OpenConnectionAsync();
+            //await using var cmd = conn.CreateCommand();
+
+            //// 使用参数化查询避免 SQL 注入
+            //cmd.CommandText = $"SELECT SUM({columnName}) FROM \"{tableName}\" WHERE {whereClause}";
+            //foreach (var param in parameters)
+            //    cmd.Parameters.Add(param);
+
+            //var result = await cmd.ExecuteScalarAsync();
+            //return result != DBNull.Value ? Convert.ToInt64(result) : 0;
+            await FTask.CompletedTask;
+            return 1;
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        /// <summary>
+        /// 从DataReader中获取BsonDocument
+        /// </summary>
+        private BsonDocument GetBsonDocumentFromReader(NpgsqlDataReader reader)
+        {
+            // var document = new BsonDocument();
+            // for (int i = 0; i < reader.FieldCount; i++)
+            // {
+            //     var name = reader.GetName(i);
+            //     var value = reader.GetValue(i);
+            //     
+            //     if (value == DBNull.Value)
+            //     {
+            //         document.Add(name, BsonNull.Value);
+            //     }
+            //     else
+            //     {
+            //         document.Add(name, new BsonValue(value));
+            //     }
+            // }
+            // return document;
+            return new BsonDocument();
+        }
+
+        /// <summary>
+        /// 将JSON查询条件转换为SQL WHERE子句
+        /// </summary>
+        private string ConvertJsonToWhereClause(string json)
+        {
+            // 这里应该实现JSON到SQL WHERE子句的转换
+            // 为简化，返回一个占位符
+            return "1=1";
+        }
+
+        /// <summary>
+        /// 获取实体的所有列名
+        /// </summary>
+        private List<string> GetColumnsForEntity<T>(T entity) where T : Entity
+        {
+            // var columns = new List<string>();
+            // var properties = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            // foreach (var property in properties)
+            // {
+            //     columns.Add(property.Name);
+            // }
+            // return columns;
+            return new List<string>();
+        }
+
+        /// <summary>
+        /// 获取实体的所有值
+        /// </summary>
+        private List<object> GetValuesForEntity<T>(T entity) where T : Entity
+        {
+            // var values = new List<object>();
+            // var properties = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            // foreach (var property in properties)
+            // {
+            //     values.Add(property.GetValue(entity));
+            // }
+            // return values;
+            return new List<object>();
+        }
+
+        /// <summary>
+        /// 为命令添加实体参数
+        /// </summary>
+        private void AddParametersForEntity<T>(NpgsqlCommand cmd, T entity, List<string> columns) where T : Entity
+        {
+            // foreach (var column in columns)
+            // {
+            //     var property = typeof(T).GetProperty(column);
+            //     if (property != null)
+            //     {
+            //         var value = property.GetValue(entity);
+            //         cmd.Parameters.AddWithValue(column, value ?? DBNull.Value);
+            //     }
+            // }
+        }
+
+        /// <summary>
+        /// 从索引键定义获取列名
+        /// </summary>
+        private string GetIndexColumns(object key)
+        {
+            // 这里应该实现从索引键定义获取列名的逻辑
+            // 为简化，返回一个占位符
+            return "column";
+        }
+
+        /// <summary>
+        /// 从索引键定义获取索引类型
+        /// </summary>
+        private string GetIndexType(object key)
+        {
+            // 这里应该实现从索引键定义获取索引类型的逻辑
+            // 为简化，返回一个占位符
+            return "USING btree";
+        }
+        #endregion
+
+    }
+}
+#endif

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Database/PostgreSQL.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Database/PostgreSQL.cs
@@ -1,0 +1,483 @@
+﻿#if FANTASY_NET
+using Fantasy.Async;
+using Fantasy.Entitas;
+using Fantasy.Serialize;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using Npgsql;
+using System.Reflection.Emit;
+using System.Threading.Tasks;
+using static Fantasy.Database.PgSession;
+
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
+#pragma warning disable CS8603 // Possible null reference return.
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
+namespace Fantasy.Database
+{
+    /// <summary>
+    /// Fantasy框架使用 PostgreSQL 数据库。
+    /// </summary>
+    public sealed partial class PostgreSQL : IDatabase, IRawHandler<NpgsqlDataSource>
+    {
+        internal FTaskFlowLock FlowLock { get; private set; }
+        internal const int FTaskCountLimit = 1024;
+
+        /// <summary>
+        /// 所在Scene
+        /// </summary>
+        public Scene Scene { get; private set; }
+        /// <summary>
+        /// 序列化器
+        /// </summary>
+        public ISerialize Serializer { get; private set; }
+        /// <summary>
+        /// 当前数据的类型
+        /// </summary>
+        public DatabaseType GetDatabaseType { get; } = DatabaseType.PostgreSQL;
+        /// <summary>
+        /// 这个数据库的工作职责
+        /// </summary>
+        public int Duty { get; private set; }
+        /// <summary>
+        /// PgSQL原生操作柄
+        /// </summary>
+        public NpgsqlDataSource RawHandler { get; private set; }
+
+        #region Basic
+
+        /// <summary>
+        /// 初始化 PgSQL 数据库连接。
+        /// </summary>
+        /// <param name="duty">工作职责。</param>
+        /// <param name="scene">场景对象。</param>
+        /// <param name="worldServices">世界服务构建。</param>
+        /// <param name="connectionString">数据库连接字符串。</param>
+        /// <param name="dbName">数据库名称。</param>
+        /// <returns>初始化后的数据库实例。</returns>
+        public IDatabase Initialize(Scene scene, ref ServiceCollection worldServices,int duty, string connectionString, string dbName)
+        {
+            Scene = scene;
+            Duty = duty;
+            Serializer = SerializerManager.GetSerializer(FantasySerializerType.Bson);
+
+            if (DatabaseSetting.PostgreSQLCustomInitialize != null)
+            {
+                RawHandler = DatabaseSetting.PostgreSQLCustomInitialize(new DatabaseCustomConfig()
+                {
+                    Scene = scene,
+                    ConnectionString = connectionString,
+                    DBName = dbName
+                });
+            }
+            else try
+            {
+                RawHandler = NpgsqlDataSource.Create(connectionString);
+            }
+            catch(Exception e) {
+                throw new Exception($" ( PgSQL Building ConnectionString Err : {connectionString} )\n {e}");
+            }
+
+            // 为World服务 注册 PgSession 池。
+            // 注意, DbContext的池化会将Scope也一并连带, 这导致的直接结果是, 每次调用Open取池中的PgSession时, Scoped服务都是跟初始保持一致的,
+            // 因此 池化的PgSession 不允许使用动态Scoped服务 (非动态Scoped服务无影响)。
+            // 详情 请阅读 AddDbContextPool 微软官方的注释以获得更多理解。
+            worldServices.AddDbContextPool<PgSession>(contextOptionsBuilder =>
+            {
+                contextOptionsBuilder.UseNpgsql(RawHandler).UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking); // 默认关闭 ChangeTracking，让 EFCore 不跟踪实体
+#if DEBUG
+                contextOptionsBuilder.EnableSensitiveDataLogging(true);
+#endif
+            }, poolSize: FTaskCountLimit);
+
+            //为World服务 注册非池化版本的PgSession。
+            worldServices.AddDbContext<PgSessionUnPooled>(contextOptionsBuilder =>
+            {
+                contextOptionsBuilder.UseNpgsql(RawHandler).UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking); // 默认关闭 ChangeTracking，让 EFCore 不跟踪实体
+#if DEBUG
+                contextOptionsBuilder.EnableSensitiveDataLogging(true);
+#endif
+            });
+
+            //分别初始化池化Session和非池化Session连接( 这一步同时也会构建 Entity - Table映射模型 )
+            try
+            {
+                var optionsBuilder = new DbContextOptionsBuilder<PgSession>();
+                optionsBuilder.UseNpgsql(RawHandler);
+                var pgSessionTest = new PgSession(optionsBuilder.Options);
+                pgSessionTest.Database.OpenConnection();
+                pgSessionTest.Dispose();
+
+                var optionsBuilderForNonPooled = new DbContextOptionsBuilder<PgSessionUnPooled>();
+                optionsBuilderForNonPooled.UseNpgsql(RawHandler);
+                var pgSessionNonPooledTest = new PgSessionUnPooled(optionsBuilderForNonPooled.Options);
+                pgSessionNonPooledTest.Database.OpenConnection();
+                pgSessionNonPooledTest.Dispose();
+            }
+            catch (Exception ex) {
+                throw new Exception($"( Failed to init PgSession. \"{GetConnectionInfoWithoutPassword()}\") :\n {ex} ");
+            }
+
+            Log.Info("(PgSQL is able to be connected.) \n " + GetConnectionInfoWithoutPassword());
+
+            var pgDbHash = GetType().TypeHandle.Value.ToInt64();
+            FlowLock = (FlowLock == null)
+                    ? new FTaskFlowLock(FTaskCountLimit, scene.CoroutineLockComponent, pgDbHash)
+                    : FlowLock.Reset(scene.CoroutineLockComponent, pgDbHash);
+
+            return this;
+        }
+
+        /// <summary>
+        /// 异步销毁限流锁
+        /// </summary>
+        /// <returns></returns>
+        public async FTask DisposeFlowLockAsync()
+        {
+            await FlowLock.DisposeAsync();
+        }
+
+        /// <summary>
+        /// 销毁释放资源。
+        /// </summary>
+        public void Dispose()
+        {
+            DisposeFlowLockAsync().Coroutine(); // ← 销毁FTaskFlowLock, 注意这里是开了协程的
+            // 清理资源。
+            Scene = null;
+            Serializer = null;
+            RawHandler?.Dispose();
+            RawHandler = null;
+            FlowLock = null;
+        }
+        #endregion
+
+        #region  Use Session
+
+        /// <summary>
+        /// 使用数据库: 创建作用域并获取 Db对话实例。
+        /// (这里的 SqlSession 超过 scope 会自动Dispose, 确保外部使用了using 管理作用域, 即可自动将SqlSession返还池中)
+        /// </summary>
+        /// <param name="session"> out：获取到的 数据库对话 实例（可能为 null）</param>
+        /// <param name="useSessionFromPool"> 本次连接是否从池中取 DbSession, 默认为为true; 
+        /// 解释如下 : DbSession 的父类是微软提供的 DbContext。使用DbContext分池化和实例化两种用法，
+        /// 池化模式每次会尝试从DbContextPool当中取一个DbContext, 相比于每次都实例化, 池化的GC压力较小且性能略优,
+        /// 在我们框架中, PgSQL 从池中取的是 PgSession; 
+        /// 然而, 由于 PgSession 当中保存了一些数据库操作的状态, 池化模式在少数高并发的边缘情况可能存在副作用, 需特别留意, 
+        /// 详情请参考微软EFCore官方手册对DbContextPool的说明以获得更多理解。 </param>
+        /// <returns>创建的作用域（外部通过 using 释放）</returns>
+        public AsyncServiceScope Use(out IDbSession? session,bool useSessionFromPool = true)
+        {
+            var scope = Scene.World.ServiceProvider.CreateAsyncScope();
+            PgSession? pgSession = null; 
+            try
+            {
+                if (useSessionFromPool)
+                    pgSession = scope.ServiceProvider.GetRequiredService<PgSession>();
+                else
+                    pgSession = scope.ServiceProvider.GetRequiredService<PgSessionUnPooled>();
+
+                pgSession.SetPg(this);
+                session = pgSession;
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"( Critical Emergency! PgSQL failed to get connection! ) \n " +
+            $"{GetConnectionInfoWithoutPassword()}\n", ex);
+                pgSession?.Dispose();
+                session = null;
+            }
+            return scope;
+        }
+
+        /// <summary>
+        /// 使用数据库: 创建作用域并获取 Db会话实例。SqlSession 类型版本。
+        /// </summary>
+        /// <param name="session">out：获取到的 SQL数据库对话 实例（可能为 null）</param>
+        /// <param name="useSessionFromPool"> 本次连接是否从池中取 DbSession, 默认为为true; 
+        /// 解释如下 : DbSession 的父类是微软提供的 DbContext。使用DbContext分池化和实例化两种用法，
+        /// 池化模式每次会尝试从DbContextPool当中取一个DbContext, 相比于每次都实例化, 池化的GC压力较小且性能略优,
+        /// 在我们框架中, PgSQL 从池中取的是 PgSession; 
+        /// 然而, 由于 PgSession 当中保存了一些数据库操作的状态, 池化模式在少数高并发的边缘情况可能存在副作用, 需特别留意, 
+        /// 详情请参考微软EFCore官方手册对DbContextPool的说明以获得更多理解。 </param>
+        /// <returns>创建的作用域（外部通过 using 释放）</returns>
+        /// <returns>作用域（外部通过 using 释放）</returns>
+        public AsyncServiceScope Use(out PgSession? session, bool useSessionFromPool = true)
+        {
+            var scope = Scene.World.ServiceProvider.CreateAsyncScope();
+            PgSession? pgSession = null;
+            try
+            {
+                if (useSessionFromPool)
+                    pgSession = scope.ServiceProvider.GetRequiredService<PgSession>();
+                else
+                    pgSession = scope.ServiceProvider.GetRequiredService<PgSessionUnPooled>();
+
+                pgSession.SetPg(this);
+                session = pgSession;
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"( Critical Emergency! PgSQL failed to get connection! ) \n " +
+          $"{GetConnectionInfoWithoutPassword()}\n", ex);
+                pgSession?.Dispose();
+                session = null;
+            }
+            return scope;
+        }
+
+        /// <summary>
+        /// 直接传入一个函数操作数据库, 函数执行完会自动结束 PgSession；
+        /// 注意: 这一方法写起来更方便, 但如果传入函数闭包了外部变量, 编译器将会生成DisplayClass, 导致一定的GC压力。 
+        /// </summary>
+        /// <param name="asyncFunc"></param>
+        /// <param name="useSessionFromPool"> 本次连接是否从池中取 DbSession, 默认为为true; 
+        /// 解释如下 : DbSession 的父类是微软提供的 DbContext。使用DbContext分池化和实例化两种用法，
+        /// 池化模式每次会尝试从DbContextPool当中取一个DbContext, 相比于每次都实例化, 池化的GC压力较小且性能略优,
+        /// 在我们框架中, PgSQL 从池中取的是 PgSession; 
+        /// 然而, 由于 PgSession 当中保存了一些数据库操作的状态, 池化模式在少数高并发的边缘情况可能存在副作用, 需特别留意, 
+        /// 详情请参考微软EFCore官方手册对DbContextPool的说明以获得更多理解。 </param>
+        public async FTask Invoke(Func<PgSession?, FTask> asyncFunc, bool useSessionFromPool = true)
+        {
+            await using AsyncServiceScope scope = Scene.World.ServiceProvider.CreateAsyncScope();
+            PgSession? pgSession = null;
+            try
+            {
+                if (useSessionFromPool)
+                    pgSession = scope.ServiceProvider.GetRequiredService<PgSession>(); //TODO 需要验证一下这里拿到的PgSession是自动Connection还是手动的
+                else
+                    pgSession = scope.ServiceProvider.GetRequiredService<PgSessionUnPooled>();
+
+                pgSession.SetPg(this);
+                await asyncFunc(pgSession);
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"( Critical Emergency! PgSQL failed to get connection! ) \n " +
+           $"{GetConnectionInfoWithoutPassword()}\n", ex);
+                await asyncFunc(pgSession);
+            }
+        }
+
+        /// <summary>
+        /// 通过 IDbSession 操作数据库。直接传入一个函数, 执行完会自动结束 PgSession；
+        /// 注意: 这一方法写起来更方便, 但如果传入函数闭包了外部变量, 编译器将会生成DisplayClass, 导致一定的GC压力。 
+        /// </summary>
+        /// <param name="asyncFunc"></param>
+        /// <param name="useSessionFromPool"> 本次连接是否从池中取 DbSession, 默认为为true; 
+        /// 解释如下 : DbSession 的父类是微软提供的 DbContext。使用DbContext分池化和实例化两种用法，
+        /// 池化模式每次会尝试从DbContextPool当中取一个DbContext, 相比于每次都实例化, 池化的GC压力较小且性能略优,
+        /// 在我们框架中, PgSQL 从池中取的是 PgSession; 
+        /// 然而, 由于 PgSession 当中保存了一些数据库操作的状态, 池化模式在少数高并发的边缘情况可能存在副作用, 需特别留意, 
+        /// 详情请参考微软EFCore官方手册对DbContextPool的说明以获得更多理解。 </param>
+        public async FTask Invoke(Func<IDbSession?, FTask> asyncFunc, bool useSessionFromPool = true)
+        {
+            await using AsyncServiceScope scope = Scene.World.ServiceProvider.CreateAsyncScope();
+            PgSession? pgSession = null;
+            try
+            {
+                if (useSessionFromPool)
+                    pgSession = scope.ServiceProvider.GetRequiredService<PgSession>(); //TODO 需要验证一下这里拿到的PgSession是自动Connection还是手动的
+                else
+                    pgSession = scope.ServiceProvider.GetRequiredService<PgSessionUnPooled>();
+
+                pgSession.SetPg(this);
+                await asyncFunc(pgSession);
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"( Critical Emergency! PgSQL failed to get connection! ) \n " +
+               $"{GetConnectionInfoWithoutPassword()}\n", ex);
+                await asyncFunc(pgSession);
+            }
+        }
+
+        /// <summary>
+        /// 获取Connection信息, 规避密码
+        /// </summary>
+        /// <returns></returns>
+        public string GetConnectionInfoWithoutPassword() {
+            var parts = RawHandler.ConnectionString?.Split(';') ?? Array.Empty<string>();
+
+            string GetValue(string key) =>
+                parts.FirstOrDefault(p => p.StartsWith(key + "=", StringComparison.OrdinalIgnoreCase))
+                     ?.Substring(key.Length + 1) ?? "Unknown";
+
+            var host = GetValue("Host");
+            var port = GetValue("Port");
+            var username = GetValue("Username");
+            var database = GetValue("Database");
+            return $"---------- ( Host={host}; Port={port}; Username={username}; Database={database} ) ----------";
+        }
+
+        #endregion
+
+        #region Deployment
+
+        /// <summary>
+        /// 快速部署, 一次性快速创建所有标记为 [Table] 或 [FTable] 的实体的表。
+        /// (建议仅开发时使用,正式部署后请走严格的数据库迁移流程)
+        /// </summary>
+        /// <returns></returns>
+        public async FTask FastDeploy()
+        {
+            //TODO 暂时这样简单粗暴, 之后再改成像SqlSugar那样可以根据标签精细管理迁移策略
+            await using (Use(out PgSession? pgSession))
+            {
+                if (pgSession != null)
+                {
+                    await pgSession.Database.EnsureCreatedAsync();
+                }
+                else
+                    Log.Debug(" Failed to connect to pgSession");
+            }
+        }
+
+        /// <summary>
+        /// 清空逻辑数据库。用于开发时将整个数据库全部清除(危险操作, 仅开发时快速迭代期使用，仅针对数据库超级用户进行)
+        /// </summary>
+        /// <returns></returns>
+        public async FTask DropEverything()
+        {
+            //TODO 暂时这样简单粗暴, 之后再改成像SqlSugar那样可以根据标签精细管理迁移策略
+            await using (Use(out PgSession? pgSession))
+            {
+                if (pgSession != null)
+                    await pgSession.Database.EnsureDeletedAsync();
+                else
+                    Log.Debug(" Failed to connect to pgSession");
+            }
+        }
+
+        /// <summary>
+        /// 创建表。无效。
+        /// 与文档数据库不同, SQL 数据库不鼓励在运行时随意用代码建表，
+        /// 因为这会在生产环境中导致严重的数据库版本管理困难。
+        /// 如果是在开发阶段，可以适当使用 快速部署 或自动迁移来快速创建表以便快速迭代；
+        /// 但如果业务已经上线，请严格遵循 EF Core 的流程：生成迁移 -> 同步数据库。
+        /// </summary>
+        [Obsolete(" (Invalid operation!!)  " +
+       " SQL databases do not recommend creating tables at runtime using code arbitrarily, " +
+       "as this can cause serious difficulties in database version management in production. \r\n" +
+       "If you are in the development stage, you may appropriately use FastDeploy or automatic migrations to quickly create tables for testing purposes; " +
+       "however, if your application is already in production, you should strictly follow the EF Core workflow: " +
+       "generate migrations -> synchronize the database.\r\n", true)]
+        public async FTask CreateDbSet<T>(string Name = null) where T : Entity
+        {
+            Log.Warning(" (Invalid operation!!)  " +
+            " SQL databases do not recommend creating tables at runtime using code arbitrarily, " +
+            "as this can cause serious difficulties in database version management in production. \r\n" +
+            "If you are in the development stage, you may appropriately use FastDeploy or automatic migrations to quickly create tables for testing purposes; " +
+            "however, if your application is already in production, you should strictly follow the EF Core workflow: " +
+            "generate migrations -> synchronize the database.\r\n");
+            await FTask.CompletedTask;
+        }
+        /// <summary>
+        /// 创建表。无效。
+        /// 与文档数据库不同, SQL 数据库不鼓励在运行时随意用代码建表，
+        /// 因为这会在生产环境中导致严重的数据库版本管理困难。
+        /// 如果是在开发阶段，可以适当使用 快速部署 或自动迁移来快速创建表以便快速迭代；
+        /// 但如果业务已经上线，请严格遵循 EF Core 的流程：生成迁移 -> 同步数据库。
+        /// </summary>
+        [Obsolete(" (Invalid operation!!)  " +
+               " SQL databases do not recommend creating tables at runtime using code arbitrarily, " +
+               "as this can cause serious difficulties in database version management in production. \r\n" +
+               "If you are in the development stage, you may appropriately use FastDeploy or automatic migrations to quickly create tables for testing purposes; " +
+               "however, if your application is already in production, you should strictly follow the EF Core workflow: " +
+               "generate migrations -> synchronize the database.\r\n", true)]
+        public async FTask CreateDbSet(Type type, string Name = null)
+        {
+            Log.Warning(" (Invalid operation!!)  " +
+            " SQL databases do not recommend creating tables at runtime using code arbitrarily, " +
+            "as this can cause serious difficulties in database version management in production. \r\n" +
+            "If you are in the development stage, you may appropriately use FastDeploy or automatic migrations to quickly create tables for testing purposes; " +
+            "however, if your application is already in production, you should strictly follow the EF Core workflow: " +
+            "generate migrations -> synchronize the database.\r\n");
+            await FTask.CompletedTask;
+        }
+
+        #endregion
+
+        #region Index
+
+        /// <summary>
+        /// 创建数据库索引（加锁）。
+        /// </summary>
+        /// <param name="table"></param>
+        /// <param name="keys"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <code>
+        /// 使用例子(可多个):
+        /// 1 : Builders.IndexKeys.Ascending(d=>d.Id)
+        /// 2 : Builders.IndexKeys.Descending(d=>d.Id).Ascending(d=>d.Name)
+        /// 3 : Builders.IndexKeys.Descending(d=>d.Id),Builders.IndexKeys.Descending(d=>d.Name)
+        /// </code>
+        public async FTask CreateIndex<T>(string table, params object[]? keys) where T : Entity
+        {
+            // if (keys == null || keys.Length <= 0)
+            // {
+            //     return;
+            // }
+            // 
+            // var tableName = GetTableName<T>(table);
+            // 
+            // using (await _dataBaseLock.Wait(RandomHelper.RandInt64() % DefaultTaskSize))
+            // {
+            //     await _connection.OpenAsync();
+            //     for (int i = 0; i < keys.Length; i++)
+            //     {
+            //         var indexName = $"{tableName}_index_{i}";
+            //         var columns = GetIndexColumns(keys[i]);
+            //         var indexType = GetIndexType(keys[i]);
+            //         
+            //         using (var cmd = _connection.CreateCommand())
+            //         {
+            //             cmd.CommandText = $"CREATE INDEX IF NOT EXISTS \"{indexName}\" ON \"{tableName}\" {indexType} ({columns})";
+            //             await cmd.ExecuteNonQueryAsync();
+            //         }
+            //     }
+            //     await _connection.CloseAsync();
+            // }
+            await FTask.CompletedTask;
+        }
+
+        /// <summary>
+        /// 创建数据库的索引（加锁）。
+        /// </summary>
+        /// <typeparam name="T">实体类型。</typeparam>
+        /// <param name="keys">索引键定义。</param>
+        public async FTask CreateIndex<T>(params object[]? keys) where T : Entity
+        {
+            // if (keys == null || keys.Length <= 0)
+            // {
+            //     return;
+            // }
+            // 
+            // var tableName = GetTableName<T>();
+            // 
+            // using (await _dataBaseLock.Wait(RandomHelper.RandInt64() % DefaultTaskSize))
+            // {
+            //     await _connection.OpenAsync();
+            //     for (int i = 0; i < keys.Length; i++)
+            //     {
+            //         var indexName = $"{tableName}_index_{i}";
+            //         var columns = GetIndexColumns(keys[i]);
+            //         var indexType = GetIndexType(keys[i]);
+            //         
+            //         using (var cmd = _connection.CreateCommand())
+            //         {
+            //             cmd.CommandText = $"CREATE INDEX IF NOT EXISTS \"{indexName}\" ON \"{tableName}\" {indexType} ({columns})";
+            //             await cmd.ExecuteNonQueryAsync();
+            //         }
+            //     }
+            //     await _connection.CloseAsync();
+            // }
+            await FTask.CompletedTask;
+        }
+
+        #endregion
+    }
+}
+#endif

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Database/限流锁测试_用完删.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Database/限流锁测试_用完删.cs
@@ -1,0 +1,192 @@
+﻿
+#region 测试用的, 之后会全部删掉的
+#if DEBUG
+
+namespace Fantasy.Database
+{
+    using Fantasy.Async;
+    using Fantasy.Entitas;
+    using Fantasy.Helper;
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using static System.Formats.Asn1.AsnWriter;
+
+
+    /// 限流锁测试。
+    public enum 限流锁测试
+    {
+        /// 注意到, 之前MongoDb访问层的API大量使用了(随机数 % FTask限额)的运算方式来限流, 缺点是: 可读性差、不可监控、会产生少量随机数重复阻塞
+        随机数锁,
+        /// 
+        信号量锁,
+        /// 
+        信号量锁住Id
+    }
+
+    public sealed partial class MongoDb
+    {
+        const int 并发数 = MongoDb.FTaskCountLimit * 5;  //同时发起远超任务数量上限,达5倍的请求
+        //const int 并发数 = 1024; //同时少量请求, 不超过任务数量上限
+        const int 最后几条必Log = 10;
+
+        private Stopwatch? 随机数协程锁总耗时;
+        private Stopwatch? 信号量总耗时;
+
+        private CoroutineLock? TestLockForRandomNumber;
+
+        /// <summary>
+        /// 在配置了MongoDB的任何Scene当中调用这里, 测试两种限流锁在处理并发请求的效果
+        /// </summary>
+        public async FTask 开始测试(限流锁测试 lockType) {
+
+            TestLockForRandomNumber = Scene.CoroutineLockComponent.Create(GetType().TypeHandle.Value.ToInt64());
+            await FTask.CompletedTask;
+            switch (lockType)
+            {
+                case 限流锁测试.随机数锁:
+                    {
+                        Log.Debug($"Scene({Scene.SceneConfigId})随机数锁 控流测试开始");
+                        随机数协程锁总耗时 = System.Diagnostics.Stopwatch.StartNew();
+                        for (int t = 0; t < 并发数; t++)
+                        {
+                            随机数协程锁流量控制测试(t, 并发数, Random.Shared.NextDouble() < 0.005).Coroutine();
+                        }
+                        break;
+                    }
+                case 限流锁测试.信号量锁:
+                    {
+                        Log.Debug($"Scene({Scene.SceneConfigId})信号量锁 控流测试开始");
+                        信号量总耗时 = System.Diagnostics.Stopwatch.StartNew();
+                        for (int t = 0; t < 并发数; t++)
+                        {
+                            信号量流量控制测试(t, 并发数, Random.Shared.NextDouble() < 0.005).Coroutine();
+                        }
+                        break;
+                    }
+                case 限流锁测试.信号量锁住Id:
+                    {
+                        信号量总耗时 = System.Diagnostics.Stopwatch.StartNew();
+                        for (int t = 0; t < 并发数; t++)
+                        {
+                            信号量针对Id测试(t, 并发数, 1, Random.Shared.NextDouble() < 0.005).Coroutine();
+                        }
+                        break;
+                    }
+            }
+                     
+        }
+
+        internal class TestEntity : Entity { }
+        private async FTask 测试跑的内容()
+        {
+            await _dbSession.Exist<TestEntity>();
+            await _dbSession.Count<TestEntity>();
+            await FTask.Wait(Scene, 200);
+        }
+
+        internal async FTask 随机数协程锁流量控制测试(int index, int 总并发, bool 随机打印)
+        {
+            Stopwatch 单次耗时;
+            long random = RandomHelper.RandInt64() % (MongoDb.FTaskCountLimit / 2);
+            //这里由于随机生成的int可能为正负, 所以要取绝对值, 否则没法正确限制Task数量
+            using (await TestLockForRandomNumber!.Wait(Math.Abs(RandomHelper.RandInt64() % MongoDb.FTaskCountLimit))) 
+            {
+                 单次耗时 = Stopwatch.StartNew();
+                await 测试跑的内容();
+            }
+            单次耗时.Stop();
+            if (index > 总并发 - 最后几条必Log || 随机打印)
+                Log.Info($"FTask随机锁限流 操作数据库 {index} 次: {单次耗时.ElapsedMilliseconds} ms; 总耗时: {随机数协程锁总耗时!.ElapsedMilliseconds} ms");
+        }
+
+        internal async FTask 信号量流量控制测试(int index, int 总并发, bool 随机打印)
+        {
+            Stopwatch 单次耗时;
+            using (await FlowLock.WaitIfTooMuch())
+            {
+                单次耗时 = Stopwatch.StartNew();
+                await 测试跑的内容();
+            }
+
+            单次耗时.Stop();
+            if (index > 总并发 - 最后几条必Log || 随机打印)
+                Log.Debug($"FTask信号量限流 操作数据库 {index} 次: {单次耗时.ElapsedMilliseconds} ms; 总耗时: {信号量总耗时!.ElapsedMilliseconds} ms");
+        }       
+
+        internal async FTask 信号量针对Id测试(int index, int 总并发, int waitForId, bool 随机打印)
+        {
+            Stopwatch 单次耗时;
+            using (await FlowLock.Wait(waitForId))//等待
+            {
+                单次耗时 = Stopwatch.StartNew();
+                await 测试跑的内容();
+                Log.Debug($"index{index} waitForId:{waitForId}");
+            }
+
+            单次耗时.Stop();
+            if (index > 总并发 - 最后几条必Log || 随机打印)
+                Log.Debug($"单次耗时：{单次耗时.ElapsedMilliseconds} ms; 总耗时：{信号量总耗时!.ElapsedMilliseconds} ms");
+        }
+
+        /// <summary>
+        /// 检查信号量锁的并发有效性
+        /// </summary>
+        internal async FTask 开始信号量锁有效性测试()
+        {
+            const int 并发数 = MongoDb.FTaskCountLimit * 2;
+            const int 流量上限 = MongoDb.FTaskCountLimit;
+
+            Log.Debug($"[信号量锁有效性测试] 启动 {并发数} 个任务，流量上限 {流量上限}");
+
+            int 正在执行数 = 0;
+            int 最大并发数 = 0;
+            bool 违反限流 = false;
+
+            var 测试锁 = FlowLock;
+
+            // 启动所有任务
+            var tasks = new List<FTask>();
+            for (int i = 0; i < 并发数; i++)
+            {
+                tasks.Add(TestOne(i));
+            }
+
+            // 等待所有任务执行完毕
+            await FTask.WaitAll(tasks);
+
+            if (违反限流)
+                Log.Error($"❌ [信号量锁有效性测试] 失败！并发超出限流值 {流量上限}！");
+            else
+                Log.Debug($"✅ [信号量锁有效性测试] 通过！最大并发={最大并发数}");
+
+            async FTask TestOne(int index)
+            {
+                using (await 测试锁.WaitIfTooMuch($"Test{index}"))
+                {
+                    int 当前 = Interlocked.Increment(ref 正在执行数);
+                    int 当前最大 = Math.Max(最大并发数, 当前);
+                    Interlocked.Exchange(ref 最大并发数, 当前最大);
+
+                    if (当前 > 流量上限)
+                    {
+                        违反限流 = true;
+                        Log.Error($"❌ 并发数超过上限！当前={当前}, 限制={流量上限}");
+                    }
+
+                    // 模拟执行时间（越短越容易暴露锁问题）
+                    await FTask.WaitFrame(Scene);
+                    await FTask.WaitFrame(Scene);
+                    Interlocked.Decrement(ref 正在执行数);
+                }
+            }
+        }
+
+    }
+}
+#endif
+#endregion

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Entitas/Component/CoroutineLock/CoroutineLock.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Entitas/Component/CoroutineLock/CoroutineLock.cs
@@ -1,6 +1,6 @@
-using System;
-using System.Collections.Generic;
 using Fantasy.Pool;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
@@ -16,29 +16,56 @@ namespace Fantasy.Async
         /// </summary>
         public CoroutineLockPool() : base(2000) { }
     }
-    
+
+    /// <summary>
+    /// 对锁的抽象
+    /// </summary>
+    public interface ILock
+    {
+        /// <summary>
+        /// 锁职责
+        /// </summary>
+        public long LockDuty { get; }
+        /// <summary>
+        /// 释放掉
+        /// </summary>
+        void Release(long waitingKey);
+    }
+
+    /// <summary>
+    /// 协程锁。对协程锁的基本抽象, 方便用于扩展协程锁。
+    /// </summary>
+    internal interface ICoroutineLock: ILock
+    {
+        public Scene Scene { get; }
+        public CoroutineLockComponent CoroutineLockComponent { get; }
+        FTask<WaitCoroutineLock> Wait(long waitForId, string tag = null, int timeOut = 30000);
+    }
+
     /// <summary>
     /// 协程锁
     /// </summary>
-    public sealed class CoroutineLock : IPool, IDisposable
+    public sealed class CoroutineLock : ICoroutineLock, IPool, IDisposable
     {
-        private Scene _scene;
-        private CoroutineLockComponent _coroutineLockComponent;
+        /// 所在Scene
+        public Scene Scene { get; private set; }
+        /// 池源
+        public CoroutineLockComponent CoroutineLockComponent { get; private set; }
         private readonly Dictionary<long, CoroutineLockQueue> _queue = new Dictionary<long, CoroutineLockQueue>();
         /// <summary>
         /// 表示是否是对象池中创建的
         /// </summary>
         private bool _isPool;
         /// <summary>
-        /// 协程锁的类型
+        /// 协程锁职责
         /// </summary>
-        public long CoroutineLockType { get; private set; }
+        public long LockDuty { get; private set; }
 
-        internal void Initialize(CoroutineLockComponent coroutineLockComponent, ref long coroutineLockType)
+        internal void Initialize(CoroutineLockComponent coroutineLockComponent, ref long lockDuty)
         {
-            _scene = coroutineLockComponent.Scene;
-            CoroutineLockType = coroutineLockType;
-            _coroutineLockComponent = coroutineLockComponent;
+            Scene = coroutineLockComponent.Scene;
+            LockDuty = lockDuty;
+            CoroutineLockComponent = coroutineLockComponent;
         }
         /// <summary>
         /// 销毁协程锁，如果调用了该方法，所有使用当前协程锁等待的逻辑会按照顺序释放锁。
@@ -49,47 +76,47 @@ namespace Fantasy.Async
             {
                 while (TryCoroutineLockQueueDequeue(coroutineLockQueue)) { }
             }
-            
+
             _queue.Clear();
-            _scene = null;
-            CoroutineLockType = 0;
-            _coroutineLockComponent = null;
+            Scene = null;
+            LockDuty = 0;
+            CoroutineLockComponent = null;
         }
         /// <summary>
         /// 等待上一个任务完成
         /// </summary>
-        /// <param name="coroutineLockQueueKey">需要等待的Id</param>
+        /// <param name="waitForId">需要等待的Id</param>
         /// <param name="tag">用于查询协程锁的标记，可不传入，只有在超时的时候排查是哪个锁超时时使用</param>
         /// <param name="timeOut">等待多久会超时，当到达设定的时候会把当前锁给按照超时处理</param>
         /// <returns></returns>
-        public async FTask<WaitCoroutineLock> Wait(long coroutineLockQueueKey, string tag = null, int timeOut = 30000)
+        public async FTask<WaitCoroutineLock> Wait(long waitForId, string tag = null, int timeOut = 30000)
         {
-            var waitCoroutineLock = _coroutineLockComponent.WaitCoroutineLockPool.Rent(this, ref coroutineLockQueueKey, tag, timeOut);
-            
-            if (!_queue.TryGetValue(coroutineLockQueueKey, out var queue))
+            var waitCoroutineLock = CoroutineLockComponent.WaitCoroutineLockPool.Rent(this, ref waitForId, tag, timeOut);
+
+            if (!_queue.TryGetValue(waitForId, out var queue))
             {
-                queue = _coroutineLockComponent.CoroutineLockQueuePool.Rent();
-                _queue.Add(coroutineLockQueueKey, queue);
+                queue = CoroutineLockComponent.CoroutineLockQueuePool.Rent();
+                _queue.Add(waitForId, queue);
                 return waitCoroutineLock;
             }
-            
+
             queue.Enqueue(waitCoroutineLock);
             return await waitCoroutineLock.Tcs;
         }
         /// <summary>
         /// 按照先入先出的顺序，释放最早的一个协程锁
         /// </summary>
-        /// <param name="coroutineLockQueueKey"></param>
-        public void Release(long coroutineLockQueueKey)
+        /// <param name="waitingKey"></param>
+        public void Release(long waitingKey)
         {
-            if (!_queue.TryGetValue(coroutineLockQueueKey, out var coroutineLockQueue))
+            if (!_queue.TryGetValue(waitingKey, out var coroutineLockQueue))
             {
                 return;
             }
-            
+
             if (!TryCoroutineLockQueueDequeue(coroutineLockQueue))
             {
-                _queue.Remove(coroutineLockQueueKey);
+                _queue.Remove(waitingKey);
             }
         }
 
@@ -97,19 +124,19 @@ namespace Fantasy.Async
         {
             if (!coroutineLockQueue.TryDequeue(out var waitCoroutineLock))
             {
-                _coroutineLockComponent.CoroutineLockQueuePool.Return(coroutineLockQueue);
+                CoroutineLockComponent.CoroutineLockQueuePool.Return(coroutineLockQueue);
                 return false;
             }
-            
+
             if (waitCoroutineLock.TimerId != 0)
             {
-                _scene.TimerComponent.Net.Remove(waitCoroutineLock.TimerId);
+                Scene.TimerComponent.Net.Remove(waitCoroutineLock.TimerId);
             }
 
             try
             {
                 // 放到下一帧执行,如果不这样会导致逻辑的顺序不正常。
-                _scene.ThreadSynchronizationContext.Post(waitCoroutineLock.SetResult);
+                Scene.ThreadSynchronizationContext.Post(waitCoroutineLock.SetResult);
             }
             catch (Exception e)
             {
@@ -137,4 +164,277 @@ namespace Fantasy.Async
             _isPool = isPool;
         }
     }
+
+    /// <summary>
+    /// FTask 限流锁。 基于.NET 的信号量 (System.Threading.SemaphoreSlim) 实现。
+    /// 【用途】 
+    /// 将超过锁所设定上限数量值的并发FTask(任务)上锁, 等有空余任务位后再执行。
+    /// 也可以像普通协程锁一样锁住某个Id, 且性能会稍佳。
+    /// 
+    /// 【典型使用场合】  
+    /// 数据库操作层用其限制 FTask 数额以防止连接数据库请求并发量过大。
+    /// 
+    /// 【代价】
+    /// 由于它采用Array 分配锁钥的Id, 数组不能Clear(), 这导致每次创建或 ResizeLimit时 会产生新的数组分配, 
+    /// 非池化, 遵循引用清零自动GC的原则, 频繁创建是不可容忍的!
+    /// 强烈建议使用时根据"职责"规划，CleanAsync 之后调用 Reset 从而复用， 而不是销毁掉。
+    /// 此外, 在手动销毁、 调用 AsyncDispose 时 ,请注意其 AsyncDispose的异步性。
+    /// 
+    /// </summary>
+    public sealed class FTaskFlowLock : ICoroutineLock, IAsyncDisposable
+    {
+        /// <summary>
+        /// FTask 限制量
+        /// </summary>
+        public int FTaskFlowLimit { get; private set; }
+
+        /// <summary>
+        /// 取当前临界区中的 FTask 数量
+        /// </summary>
+        public int ActiveCount(){ return _activeCount; }
+        private int _activeCount;
+        private readonly ConcurrentDictionary<int, (string tag, DateTime start)> _tagMap = new();
+        /// <summary>
+        /// 提供读取当前活跃 tag（监控用）
+        /// </summary>
+        public IReadOnlyDictionary<int, (string tag, DateTime start)> ActiveTags => _tagMap;
+
+        private SemaphoreSlim _flowSem; // 限制总量
+        private SemaphoreSlim[] _idSem;// 按 ID 串行
+
+        /// 所在Scene
+        public Scene Scene { get; private set; }
+        /// 池源
+        public CoroutineLockComponent CoroutineLockComponent { get; private set; }
+        /// 锁职责
+        public long LockDuty { get; private set; }
+
+        /// <summary>
+        /// 构造函数, 传入初始化设置
+        /// </summary>
+        internal FTaskFlowLock(int flowLimit, CoroutineLockComponent coroutineLockComponent, long lockDuty)
+        {
+            _flowSem = new SemaphoreSlim(flowLimit, flowLimit);
+            _idSem = new SemaphoreSlim[flowLimit];
+            for (int i = 0; i < flowLimit; i++)
+                _idSem[i] = new SemaphoreSlim(1, 1);
+
+            CoroutineLockComponent = coroutineLockComponent;
+            Scene = coroutineLockComponent.Scene;
+
+            FTaskFlowLimit = flowLimit;
+            LockDuty = lockDuty;
+        }
+
+        /// <summary>
+        /// 串行等待某个Id。且同时会总体限流: 超过锁所设定上限数量值的并发FTask等到有空余任务位后再执行。
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public async FTask<WaitCoroutineLock> Wait(long waitForId, string tag = null, int timeOut = 30000)
+        {
+            // 先标记 active 增加（只在成功进入临界区时最终减掉）
+            Interlocked.Increment(ref _activeCount);
+
+            long idIndex = Math.Abs(waitForId % FTaskFlowLimit);
+            var cancelToken = new CancellationTokenSource(timeOut);// TODO 这里CancelToken的逻辑可能可以优化, 等我研究一下再来改进, 先不要在乎这些细节
+
+            try
+            {
+                // 总体限流
+                if (!await _flowSem.WaitAsync(timeOut, cancelToken.Token))
+                {
+                    throw new TimeoutException($"[FlowLock] timeout Tag={tag ?? "null"} Id={waitForId}");
+                }
+
+                // 按 id 串行等待
+                if (!await _idSem[idIndex].WaitAsync(timeOut, cancelToken.Token))
+                {
+                    _flowSem.Release();  // 没拿到 id lock，要释放之前拿到的 flow lock
+                    throw new TimeoutException($"[FlowLock] timeout Id={waitForId} Tag={tag ?? "null"}");
+                }
+
+                // 成功进入临界区：登记 tag
+                _tagMap[(int)idIndex] = (tag, DateTime.UtcNow); 
+
+                return CoroutineLockComponent.WaitCoroutineLockPool.Rent(this, ref idIndex, tag, timeOut);
+            }
+            catch
+            {
+                Interlocked.Decrement(ref _activeCount); // 失败，activeCount 回退
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// 限流: 超过锁所设定上限数量值的并发FTask等到有空余任务位后再执行。
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public async FTask<WaitCoroutineLock> WaitIfTooMuch(string tag = null, int timeOut = 30000)
+        {
+            // 先标记 active 增加（只在成功进入临界区时最终减掉）
+            Interlocked.Increment(ref _activeCount);
+            var cancelToken = new CancellationTokenSource(timeOut);// TODO 这里CancelToken的逻辑可能可以优化, 等我研究一下再来改进, 先不要在乎这些细节
+
+            try
+            {
+                // 仅限流
+                if (!await _flowSem.WaitAsync(timeOut, cancelToken.Token))
+                {
+                    throw new TimeoutException($"[FlowLock] timeout Tag={tag ?? "null"}");
+                }
+                long minusOne = -1;
+                return CoroutineLockComponent.WaitCoroutineLockPool.Rent(this, ref minusOne, tag, timeOut);
+            }
+            catch
+            {
+                Interlocked.Decrement(ref _activeCount); // 失败，activeCount 回退
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// 释放
+        /// </summary>
+        public void Release(long waitingKey) 
+        {
+            if (waitingKey == -1) //-1 说明是纯限流了, 没有对任何Id上锁, 直接跳转
+                goto SomethingMustRelease;
+
+            int idIndex = (int)waitingKey;
+            if (idIndex < 0 || idIndex >= FTaskFlowLimit)
+            {
+                Log.Error($"FTaskFlowLock.Release: invalid waitingKey {waitingKey}");
+                return;
+            }
+
+            _tagMap.TryRemove(idIndex, out _); // 移除 tag 信息（如果存在）
+            try
+            {
+                _idSem[idIndex].Release();
+            }
+            catch (SemaphoreFullException)
+            {
+                Log.Error($"FTaskFlowLock.Release: id lock {idIndex} release twice?");  // 防御性记录调试信息
+            }
+
+            SomethingMustRelease:
+
+            try
+            {
+                _flowSem.Release();
+            }
+            catch (SemaphoreFullException)
+            {
+                Log.Error($"FTaskFlowLock.Release: flow lock release twice?");
+            }
+
+            // active count 自减
+            int newVal = Interlocked.Decrement(ref _activeCount);
+            if (newVal < 0)
+            {
+                Log.Error($"FTaskFlowLock.Release: _activeCount became negative ({newVal}). Resetting to 0.");
+                Interlocked.Exchange(ref _activeCount, 0);
+            }
+        }
+
+        /// <summary>
+        /// 重置锁以供复用, 注：1. 限流大小不改变。 2.请先确保已CleanAsync。
+        /// </summary>
+        public FTaskFlowLock Reset(CoroutineLockComponent coroutineLockComponent, long newLockDuty)
+        {
+            Scene = coroutineLockComponent.Scene;
+            CoroutineLockComponent = coroutineLockComponent;
+            LockDuty = newLockDuty;
+
+            _tagMap.Clear();
+            Interlocked.Exchange(ref _activeCount, 0);
+            EnsureSemaphoresRelease();
+            return this;
+        }
+
+        /// <summary>
+        /// 重置锁限流大小, 以供复用 ，注: 1.会触发信号量重新实例化。 2.请先确保已CleanAsync，请勿在还有FTask未完成时动态调用该方法。
+        /// </summary>
+        public FTaskFlowLock ResizeLimit(int updateLimit)
+        {
+            FTaskFlowLimit = updateLimit;
+
+            _flowSem = new SemaphoreSlim(updateLimit, updateLimit);
+            if (updateLimit > _idSem.Length)
+            {
+                _idSem = new SemaphoreSlim[updateLimit];
+                for (int i = 0; i < updateLimit; i++)
+                    _idSem[i] = new SemaphoreSlim(1, 1);
+            } 
+
+            _tagMap.Clear();
+            Interlocked.Exchange(ref _activeCount, 0);
+            EnsureSemaphoresRelease();
+            return this;
+        }
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void EnsureSemaphoresRelease()
+        {
+            // flowLock 恢复满额（防御式，确保内部信号量被 reset）
+            while (_flowSem.CurrentCount < FTaskFlowLimit)
+            {
+                try { _flowSem.Release(); }
+                catch (SemaphoreFullException) { 
+                    break;     // 已经满额，无需再释放；预期内行为
+                }
+            }
+
+            // 每个 idLock 都恢复成 1
+            for (int i = 0; i < _idSem.Length; i++)
+            {
+                var sem = _idSem[i];
+                while (sem.CurrentCount < 1)
+                {
+                    try { sem.Release(); }
+                    catch (SemaphoreFullException) {
+                        break;     // 已经满额，无需再释放；预期内行为
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// 清理(异步)
+        /// </summary>
+        /// <returns></returns>
+        public async FTask<FTaskFlowLock> CleanAsync()
+        {
+            // 等待正在执行的任务（已进入临界区）的计数归零
+            while (Volatile.Read(ref _activeCount) > 0)
+            {
+                await Task.Delay(20);
+            }
+
+            // 清理内部字典
+            _tagMap.Clear();
+            Scene = null;
+            CoroutineLockComponent = null;
+            return this;
+        }
+
+        /// <summary>
+        /// 销毁(异步)
+        /// </summary>
+        /// <returns></returns>
+        public async ValueTask DisposeAsync()
+        {
+            await CleanAsync();
+
+            foreach (var sem in _idSem)
+            {
+                try { sem.Dispose(); } catch { }
+            }
+            try { _flowSem.Dispose(); } catch { }
+
+            _idSem = null;
+            _flowSem = null;
+        }
+    }  
 }

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Entitas/Component/CoroutineLock/CoroutineLockFrozen.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Entitas/Component/CoroutineLock/CoroutineLockFrozen.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fantasy.Async
+{
+    #region TODO 冷冻态的协程锁. 基于 .NET8的 FrozenDictionary, 效果应该会不错, 没完成, 之后有时间再做
+    ///// <summary>
+    ///// 冷冻态协程锁, 用到了 FrozenDictionary, 寻锁速度更快; 
+    ///// 那么, 代价是什么呢? 答曰:无法池化, 无手动销毁, 因为它不能Clear()也不能Dispose (),
+    ///// 只适用于确定要为哪些Key上锁的场合 (通常是框架级的)。
+    ///// </summary>
+    //public class CoroutineLockFrozen
+    //{
+    //    private Scene _scene;
+    //    private CoroutineLockComponent _coroutineLockComponent;
+    //    private readonly FrozenDictionary<long, CoroutineLockQueue> _queue;
+
+    //    /// <summary>
+    //    /// 协程锁的类型
+    //    /// </summary>
+    //    public long CoroutineLockType { get; private set; }
+
+    //    internal void Initialize(CoroutineLockComponent coroutineLockComponent, ref long coroutineLockType)
+    //    {
+    //        _scene = coroutineLockComponent.Scene;
+    //        CoroutineLockType = coroutineLockType;
+    //        _coroutineLockComponent = coroutineLockComponent;
+    //    }
+    //    /// <summary>
+    //    /// 把所有协程等待释放掉
+    //    /// </summary>
+    //    public virtual void ReleaseAllWaiters() {
+    //        foreach (var (_, coroutineLockQueue) in _queue)
+    //        {
+    //            while (TryCoroutineLockQueueDequeue(coroutineLockQueue)) { }
+    //        }
+    //    }
+    //    /// <summary>
+    //    /// 等待上一个任务完成
+    //    /// </summary>
+    //    /// <param name="coroutineLockQueueKey">需要等待的Id</param>
+    //    /// <param name="tag">用于查询协程锁的标记，可不传入，只有在超时的时候排查是哪个锁超时时使用</param>
+    //    /// <param name="timeOut">等待多久会超时，当到达设定的时候会把当前锁给按照超时处理</param>
+    //    /// <returns></returns>
+    //    public async FTask<WaitCoroutineLock> Wait(long coroutineLockQueueKey, string tag = null, int timeOut = 30000)
+    //    {
+    //        var waitCoroutineLock = _coroutineLockComponent.WaitCoroutineLockPool.Rent(this, ref coroutineLockQueueKey, tag, timeOut);
+
+    //        if (!_queue.TryGetValue(coroutineLockQueueKey, out var queue))
+    //        {
+    //            queue = _coroutineLockComponent.CoroutineLockQueuePool.Rent();
+    //            _queue.Add(coroutineLockQueueKey, queue);
+    //            return waitCoroutineLock;
+    //        }
+
+    //        queue.Enqueue(waitCoroutineLock);
+    //        return await waitCoroutineLock.Tcs;
+    //    }
+    //    /// <summary>
+    //    /// 按照先入先出的顺序，释放最早的一个协程锁
+    //    /// </summary>
+    //    /// <param name="coroutineLockQueueKey"></param>
+    //    public void Release(long coroutineLockQueueKey)
+    //    {
+    //        if (!_queue.TryGetValue(coroutineLockQueueKey, out var coroutineLockQueue))
+    //        {
+    //            return;
+    //        }
+
+    //        if (!TryCoroutineLockQueueDequeue(coroutineLockQueue))
+    //        {
+    //            _queue.Remove(coroutineLockQueueKey);
+    //        }
+    //    }
+
+    //    private bool TryCoroutineLockQueueDequeue(CoroutineLockQueue coroutineLockQueue)
+    //    {
+    //        if (!coroutineLockQueue.TryDequeue(out var waitCoroutineLock))
+    //        {
+    //            _coroutineLockComponent.CoroutineLockQueuePool.Return(coroutineLockQueue);
+    //            return false;
+    //        }
+
+    //        if (waitCoroutineLock.TimerId != 0)
+    //        {
+    //            _scene.TimerComponent.Net.Remove(waitCoroutineLock.TimerId);
+    //        }
+
+    //        try
+    //        {
+    //            // 放到下一帧执行,如果不这样会导致逻辑的顺序不正常。
+    //            _scene.ThreadSynchronizationContext.Post(waitCoroutineLock.SetResult);
+    //        }
+    //        catch (Exception e)
+    //        {
+    //            Log.Error($"Error in disposing CoroutineLock: {e}");
+    //        }
+
+    //        return true;
+    //    }
+
+    //    /// <summary>
+    //    /// 获取一个值，该值指示当前实例是否为对象池中的实例。
+    //    /// </summary>
+    //    /// <returns></returns>
+    //    public bool IsPool()
+    //    {
+    //        return _isPool;
+    //    }
+
+    //    /// <summary>
+    //    /// 设置一个值，该值指示当前实例是否为对象池中的实例。
+    //    /// </summary>
+    //    /// <param name="isPool"></param>
+    //    public void SetIsPool(bool isPool)
+    //    {
+    //        _isPool = isPool;
+    //    }
+    //}
+    #endregion
+}

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Entitas/Component/CoroutineLock/WaitCoroutineLock.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Entitas/Component/CoroutineLock/WaitCoroutineLock.cs
@@ -17,7 +17,7 @@ namespace Fantasy.Async
             _coroutineLockComponent = coroutineLockComponent;
         }
 
-        public WaitCoroutineLock Rent(CoroutineLock coroutineLock, ref long coroutineLockQueueKey, string tag = null, int timeOut = 30000)
+        public WaitCoroutineLock Rent(ICoroutineLock coroutineLock, ref long coroutineLockQueueKey, string tag = null, int timeOut = 30000)
         {
             var timerId = 0L;
             var lockId = _coroutineLockComponent.LockId;
@@ -50,18 +50,18 @@ namespace Fantasy.Async
         protected override void Handler(CoroutineLockTimeout self)
         {
             var selfWaitCoroutineLock = self.WaitCoroutineLock;
-            
+
             if (self.LockId != selfWaitCoroutineLock.LockId)
             {
                 return;
             }
-            
-            Log.Error($"coroutine lock timeout CoroutineLockQueueType:{selfWaitCoroutineLock.CoroutineLock.CoroutineLockType} Key:{selfWaitCoroutineLock.CoroutineLockQueueKey} Tag:{selfWaitCoroutineLock.Tag}");
+
+            Log.Error($"coroutine lock timeout LockDuty:{selfWaitCoroutineLock.CoroutineLock.LockDuty} Key:{selfWaitCoroutineLock.CoroutineLockQueueKey} Tag:{selfWaitCoroutineLock.Tag}");
         }
     }
 
     /// <summary>
-    /// 一个协程锁的实例，用户可以用过这个手动释放锁
+    /// 一个协程锁的等待器, 用户通过这里释放锁。(通常使用 using 语句)
     /// </summary>
     public sealed class WaitCoroutineLock : IPool, IDisposable
     {
@@ -70,12 +70,12 @@ namespace Fantasy.Async
         internal long LockId { get; private set; }
         internal long TimerId { get; private set; }
         internal long CoroutineLockQueueKey { get; private set; }
-        internal CoroutineLock CoroutineLock { get; private set; }
+        internal ICoroutineLock CoroutineLock { get; private set; }
 
         private bool _isSetResult;
         private FTask<WaitCoroutineLock> _tcs;
         private WaitCoroutineLockPool _waitCoroutineLockPool;
-        internal void Initialize(CoroutineLock coroutineLock, WaitCoroutineLockPool waitCoroutineLockPool, ref long coroutineLockQueueKey, ref long timerId, ref long lockId, string tag)
+        internal void Initialize(ICoroutineLock coroutineLock, WaitCoroutineLockPool waitCoroutineLockPool, ref long coroutineLockQueueKey, ref long timerId, ref long lockId, string tag)
         {
             Tag = tag;
             LockId = lockId;

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Entitas/Component/SeparateTableComponent/SeparateTableComponent.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Entitas/Component/SeparateTableComponent/SeparateTableComponent.cs
@@ -3,6 +3,7 @@
 
 using Fantasy.Assembly;
 using Fantasy.Async;
+using Fantasy.Database;
 using Fantasy.DataStructure.Collection;
 using Fantasy.Entitas;
 using Fantasy.Entitas.Interface;
@@ -128,6 +129,7 @@ namespace Fantasy.SeparateTable
         /// 从数据库加载指定实体的所有分表数据，并自动建立父子关系。
         /// </summary>
         /// <param name="entity">需要加载分表数据的实体实例。</param>
+        /// <param name="dbSession">指定的数据库会话。</param>
         /// <typeparam name="T">实体的泛型类型，必须继承自 <see cref="Entity"/>。</typeparam>
         /// <returns>异步任务。</returns>
         /// <remarks>
@@ -141,7 +143,7 @@ namespace Fantasy.SeparateTable
         /// await separateTableComponent.Load(player); // 加载玩家的所有分表数据
         /// </code>
         /// </example>
-        public async FTask LoadWithSeparateTables<T>(T entity) where T : Entity
+        public async FTask LoadWithSeparateTables<T>(T entity,IDbSession dbSession) where T : Entity
         {
             // 检查该实体类型是否配置了分表
             if (!_separateTables.TryGetValue(entity.TypeHashCode, out var separateTables))
@@ -149,13 +151,11 @@ namespace Fantasy.SeparateTable
                 return;
             }
 
-            var worldDateBase = Scene.World.DataBase;
-
             // 遍历所有分表配置，逐个加载
             foreach (var separateTable in separateTables)
             {
-                // 使用实体ID作为查询条件，从指定的集合中加载分表实体
-                var separateTableEntity = await worldDateBase.QueryNotLock<Entity>(
+                // 使用实体ID作为查询条件，加载分表实体
+                var separateTableEntity = await dbSession.QueryNotLock<Entity>(
                     entity.Id, true, separateTable.TableName);
 
                 if (separateTableEntity == null)
@@ -172,6 +172,7 @@ namespace Fantasy.SeparateTable
         /// 将实体及其所有分表组件保存到数据库中。
         /// </summary>
         /// <param name="entity">需要保存的实体实例。</param>
+        /// <param name="dbSession">指定的数据库会话。</param>
         /// <typeparam name="T">实体的泛型类型，必须继承自 <see cref="Entity"/> 并具有无参构造函数。</typeparam>
         /// <returns>异步任务。</returns>
         /// <remarks>
@@ -186,13 +187,13 @@ namespace Fantasy.SeparateTable
         /// await separateTableComponent.Save(player); // 保存玩家及分表数据
         /// </code>
         /// </example>
-        public async FTask PersistAggregate<T>(T entity) where T : Entity, new()
+        public async FTask PersistAggregate<T>(T entity, IDbSession dbSession) where T : Entity, new()
         {
             // 检查该实体类型是否配置了分表
             if (!_separateTables.TryGetValue(entity.TypeHashCode, out var separateTables))
             {
                 // 没有分表配置，直接保存实体
-                await entity.Scene.World.DataBase.Save(entity);
+                await dbSession.Save(entity);
                 return;
             }
 
@@ -211,7 +212,7 @@ namespace Fantasy.SeparateTable
             }
 
             // 批量保存实体ID及其所有分表组件
-            await entity.Scene.World.DataBase.Save(entity.Id, saveSeparateTables);
+            await dbSession.Save(entity.Id, saveSeparateTables);
         }
 
         #endregion

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Entitas/Entity.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Entitas/Entity.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using Fantasy.Entitas.Interface;
@@ -63,6 +64,7 @@ namespace Fantasy.Entitas
         [JsonIgnore]
         [IgnoreDataMember]
         [ProtoIgnore]
+        [NotMapped]
         public Scene Scene { get; protected set; }
         /// <summary>
         /// 实体的父实体
@@ -71,6 +73,7 @@ namespace Fantasy.Entitas
         [JsonIgnore]
         [IgnoreDataMember]
         [ProtoIgnore]
+        [NotMapped]
         public Entity Parent { get; protected set; }
         /// <summary>
         /// 实体的真实Type
@@ -79,6 +82,7 @@ namespace Fantasy.Entitas
         [JsonIgnore]
         [IgnoreDataMember]
         [ProtoIgnore]
+        [NotMapped]
         public Type Type { get; protected set; }
         /// <summary>
         /// 实体的真实Type的HashCode
@@ -92,8 +96,8 @@ namespace Fantasy.Entitas
         [BsonElement("t")] [BsonIgnoreIfNull] private EntityList<Entity> _treeDb;
         [BsonElement("m")] [BsonIgnoreIfNull] private EntityList<Entity> _multiDb;
 #endif
-        [BsonIgnore] [IgnoreDataMember] [ProtoIgnore] private EntitySortedDictionary<long, Entity> _tree;
-        [BsonIgnore] [IgnoreDataMember] [ProtoIgnore] private EntitySortedDictionary<long, Entity> _multi;
+        [BsonIgnore] [IgnoreDataMember] [ProtoIgnore][NotMapped] private EntitySortedDictionary<long, Entity> _tree;
+        [BsonIgnore] [IgnoreDataMember] [ProtoIgnore][NotMapped] private EntitySortedDictionary<long, Entity> _multi;
         
         /// <summary>
         /// 获得父Entity
@@ -843,6 +847,7 @@ namespace Fantasy.Entitas
         [JsonIgnore]
         [IgnoreDataMember]
         [ProtoIgnore]
+        [NotMapped]
         public IEnumerable<Entity> ForEachMultiEntity
         {
             get
@@ -865,6 +870,7 @@ namespace Fantasy.Entitas
         [JsonIgnore]
         [IgnoreDataMember]
         [ProtoIgnore]
+        [NotMapped]
         public IEnumerable<Entity> ForEachEntity
         {
             get

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Platform/Net/ConfigTable/MachineConfig.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Platform/Net/ConfigTable/MachineConfig.cs
@@ -28,7 +28,7 @@ namespace Fantasy.Platform.Net
         /// 初始化MachineConfig
         /// </summary>
         /// <param name="machineConfigJson"></param>
-        public static void Initialize(string machineConfigJson)
+        public static void InitializeFromJson(string machineConfigJson)
         {
             try
             {

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Platform/Net/ConfigTable/ProcessConfig.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Platform/Net/ConfigTable/ProcessConfig.cs
@@ -29,7 +29,7 @@ namespace Fantasy.Platform.Net
 	    /// 初始化ProcessConfig
 	    /// </summary>
 	    /// <param name="processConfigJson"></param>
-	    public static void Initialize(string processConfigJson)
+	    public static void InitializeFromJson(string processConfigJson)
 	    {
 		    try
 		    {

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Platform/Net/ConfigTable/SceneConfig.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Platform/Net/ConfigTable/SceneConfig.cs
@@ -40,7 +40,7 @@ namespace Fantasy.Platform.Net
 		/// 初始化SceneConfig
 		/// </summary>
 		/// <param name="sceneConfigJson"></param>
-		public static void Initialize(string sceneConfigJson)
+		public static void InitializeFromJson(string sceneConfigJson)
 		{
 			try
 			{

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Platform/Net/ConfigTable/WorldConfig.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Platform/Net/ConfigTable/WorldConfig.cs
@@ -28,7 +28,7 @@ namespace Fantasy.Platform.Net
 	    /// 初始化WorldConfig
 	    /// </summary>
 	    /// <param name="worldConfigJson"></param>
-	    public static void Initialize(string worldConfigJson)
+	    public static void InitializeFromJson(string worldConfigJson)
 	    {
 		    try
 		    {
@@ -97,19 +97,29 @@ namespace Fantasy.Platform.Net
 		/// <summary>
 		/// 名称
 		/// </summary>
-		public string WorldName { get; set; } 
-		/// <summary>
-		/// 数据库连接字符串
-		/// </summary>
-		public string DbConnection { get; set; } 
-		/// <summary>
-		/// 数据库名称
-		/// </summary>
-		public string DbName { get; set; } 
-		/// <summary>
-		/// 数据库类型
-		/// </summary>
-		public string DbType { get; set; }   
-    } 
+		public string WorldName { get; set; }
+
+
+        #region ↓数据库相关, 在配置多数据库时, 如果未使用推荐的 Fantasy.config 进行配置, 请自行确保索引严格对齐↓
+
+        /// <summary>
+        /// 数据库工作职责标识
+        /// </summary>
+		public int[] DbDuty { get; set; }
+        /// <summary>
+        /// 数据库连接字符串
+        /// </summary>
+        public string[] DbConnection { get; set; }
+        /// <summary>
+        /// 数据库名称
+        /// </summary>
+        public string[] DbName { get; set; }
+        /// <summary>
+        /// 数据库类型
+        /// </summary>
+        public string[] DbType { get; set; }
+
+        #endregion
+    }
 }
 #endif

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Platform/Net/Entry.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Platform/Net/Entry.cs
@@ -64,7 +64,6 @@ public static class Entry
                         ProcessList.Add(process);
                     }
                 }
-                
                 return;
             }
             case ProcessMode.Release:
@@ -76,9 +75,24 @@ public static class Entry
                 }
                 return;
             }
-        }
+        }        
     }
-    
+
+    private static void LogFantasyVersion()
+    {
+        Log.Info($"\r\n" +
+        $"\r\n==========================================================================\r\n \r\n" +
+        $"  ███████╗ █████╗ ███╗   ██╗████████╗ █████╗  ██████╗ ██╗   ██╗\r\n" +
+        $"  ██╔════╝██╔══██╗████╗  ██║╚══██╔══╝██╔══██╗██╔════╝ ╚██╗ ██╔╝\r\n" +
+        $"  █████╗  ███████║██╔██╗ ██║   ██║   ███████║╚█████╗   ╚████╔╝ \r\n" +
+        $"  ██╔══╝  ██╔══██║██║╚██╗██║   ██║   ██╔══██║╚════██║   ╚██╔╝  \r\n" +
+        $"  ██║     ██║  ██║██║ ╚████║   ██║   ██║  ██║██████╔╝    ██║   \r\n" +
+        $"  ╚═╝     ╚═╝  ╚═╝╚═╝  ╚═══╝   ╚═╝   ╚═╝  ╚═╝╚═════╝     ╚═╝   \r\n" +
+        $"                                                            \r\n" +
+        $"                                          Version : {ProgramDefine.VERSION}\r\n");
+
+    }
+
     /// <summary>
     /// 框架初始化
     /// </summary>
@@ -88,7 +102,7 @@ public static class Entry
     {
         // 初始化Log系统
         Log.Initialize(log);
-        Log.Info($"Fantasy Version:{ProgramDefine.VERSION}");
+        LogFantasyVersion();
         // 加载Fantasy.config配置文件
         await ConfigLoader.InitializeFromXml(Path.Combine(AppContext.BaseDirectory, "Fantasy.config"));
         // 解析命令行参数

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/Scene/Scene.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/Scene/Scene.cs
@@ -11,7 +11,7 @@ using Fantasy.Pool;
 using Fantasy.Scheduler;
 using Fantasy.Timer;
 #if FANTASY_NET
-using Fantasy.DataBase;
+using Fantasy.Database;
 using Fantasy.Platform.Net;
 // using Fantasy.SingleCollection;
 using System.Runtime.CompilerServices;

--- a/Fantasy.Net/Fantasy.Net/Runtime/Core/World/Database/DbGlobalUsing.cs
+++ b/Fantasy.Net/Fantasy.Net/Runtime/Core/World/Database/DbGlobalUsing.cs
@@ -1,0 +1,3 @@
+﻿
+global using Mongo = Fantasy.Database.MongoDb;
+global using PgSQL = Fantasy.Database.PostgreSQL;

--- a/Fantasy.Net/Fantasy.SourceGenerator/Generators/SeparateTableGenerator.cs
+++ b/Fantasy.Net/Fantasy.SourceGenerator/Generators/SeparateTableGenerator.cs
@@ -114,6 +114,7 @@ namespace Fantasy.SourceGenerator.Generators
                 "System.Collections.Generic",
                 "Fantasy.Assembly",
                 "Fantasy.Entitas",
+                "Fantasy.Database",
                 "Fantasy.Entitas.Interface",
                 "Fantasy.Async"
             );
@@ -149,12 +150,12 @@ namespace Fantasy.SourceGenerator.Generators
             builder.AppendLine("{");
             builder.Indent(1);
             builder.AddXmlComment("从数据库加载指定实体的所有分表数据，并自动建立父子关系。");
-            builder.BeginMethod("public static FTask LoadWithSeparateTables<T>(this T entity) where T : Entity, new()");
-            builder.AppendLine("return entity.Scene.SeparateTableComponent.LoadWithSeparateTables(entity);");
+            builder.BeginMethod("public static FTask LoadWithSeparateTables<T>(this T entity,IDbSession dbSession) where T : Entity, new()");
+            builder.AppendLine("return entity.Scene.SeparateTableComponent.LoadWithSeparateTables(entity,dbSession);");
             builder.EndMethod();
             builder.AddXmlComment("将实体及其所有分表组件保存到数据库中。");
-            builder.BeginMethod("public static FTask PersistAggregate<T>(this T entity) where T : Entity, new()");
-            builder.AppendLine("return entity.Scene.SeparateTableComponent.PersistAggregate(entity);");
+            builder.BeginMethod("public static FTask PersistAggregate<T>(this T entity,IDbSession dbSession) where T : Entity, new()");
+            builder.AppendLine("return entity.Scene.SeparateTableComponent.PersistAggregate(entity,dbSession);");
             builder.EndMethod();
             builder.Unindent();
             builder.AppendLine("}");

--- a/examples/Config/Fantasy.config
+++ b/examples/Config/Fantasy.config
@@ -2,10 +2,14 @@
 <fantasy xmlns="http://fantasy.net/config" 
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://fantasy.net/config Fantasy.xsd">
-  <!-- 配置表路径 -->
-  <configTable path="../../../Config/Binary" />
   
-  <!-- 服务器配置 -->
+  <!-- ↓这是为了兼容旧版Fantasy的导表Json配置↓, 如果这个XML节点被注释掉, 就会以 Fantasy.config 配置为准 -->
+  <!--<configTable path="../../../../Config/Json/Server" />-->
+
+  <!-- ↓这是目前推荐使用的Fantasy框架启服配置↓ -->
+
+  <network inner="TCP" maxMessageSize="1048560" />
+  <session idleTimeout="8000" idleInterval="5000" />
   <server>
     <!-- 机器配置 -->
     <machines>
@@ -16,12 +20,19 @@
     <processes>
       <process id="1" machineId="1" startupGroup="0" />
     </processes>
-    
+
     <!-- 世界配置 -->
     <worlds>
-      <world id="1" worldName="测试服" dbConnection="" dbName="fantasy_main" dbType="MongoDB" />
+      <world id="1" worldName="WorldA">  <!-- 示范↓可在一个世界中配置多个数据库, 如果 dbConnection 设置为空 自动忽略 -->
+        <database duty="0" dbType="PgSQL" dbName="master" dbConnection="Host=localhost;Port=5432;Database=master;Username=postgres;Password=147369" />
+        <database duty="1" dbType="PgSQL" dbName="replica" dbConnection="" />
+        <database duty="2" dbType="MongoDB" dbName="doc" dbConnection="mongodb://localhost:27017/"/>
+      </world>
+      <world id="2" worldName="WorldB"> 
+        <database duty="0" dbType="MongoDB" dbName="doc" dbConnection=""/>
+      </world>
     </worlds>
-    
+
     <!-- 场景配置 -->
     <scenes>
       <scene id="1001" processConfigId="1" worldConfigId="1" sceneRuntimeMode="MultiThread" 
@@ -32,7 +43,7 @@
              sceneTypeString="Map" networkProtocol="" outerPort="0" innerPort="11003" sceneType="4" />
       <scene id="1004" processConfigId="1" worldConfigId="1" sceneRuntimeMode="MultiThread" 
              sceneTypeString="Chat" networkProtocol="" outerPort="0" innerPort="11004" sceneType="8" />
-      <scene id="1005" processConfigId="1" worldConfigId="1" sceneRuntimeMode="MultiThread" 
+      <scene id="2001" processConfigId="1" worldConfigId="2" sceneRuntimeMode="MultiThread" 
              sceneTypeString="Map" networkProtocol="" outerPort="0" innerPort="11005" sceneType="4" />
     </scenes>
     

--- a/examples/Config/Fantasy.xsd
+++ b/examples/Config/Fantasy.xsd
@@ -15,7 +15,17 @@
           <xs:annotation>
             <xs:documentation>配置表路径设置</xs:documentation>
           </xs:annotation>
+        </xs:element>      
+        <xs:element name="network" type="networkRuntimeType" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>网络运行时配置</xs:documentation>
+          </xs:annotation>
         </xs:element>
+        <xs:element name="session" type="sessionRuntimeType" minOccurs="0" maxOccurs="1">
+          <xs:annotation>
+            <xs:documentation>会话运行时配置</xs:documentation>
+          </xs:annotation>
+        </xs:element>       
         <xs:element name="server" type="serverType" minOccurs="1" maxOccurs="1">
           <xs:annotation>
             <xs:documentation>服务器配置</xs:documentation>
@@ -127,7 +137,53 @@
     </xs:sequence>
   </xs:complexType>
 
+  <!-- database的选择 -->
+  <xs:complexType name="databaseType">
+    <xs:attribute name="duty" type="xs:int" use="required">
+      <xs:annotation>
+        <xs:documentation>数据库的工作职责（ 比如主职、从职、日志职责等, 需自行约定不同 int 值）</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="dbType" use="required">
+      <xs:annotation>
+        <xs:documentation>数据库类型</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <!-- PostgreSQL -->
+          <xs:enumeration value="PostgreSQL"/>
+          <xs:enumeration value="Postgres"/>
+          <xs:enumeration value="PgSQL"/>
+          <xs:enumeration value="Pg"/>
+          <xs:enumeration value="PG"/>
+          <!-- MongoDB -->
+          <xs:enumeration value="MongoDB"/>
+          <xs:enumeration value="Mongo"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="dbName" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>数据库名称</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="dbConnection" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>数据库连接字符串</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
   <xs:complexType name="worldType">
+    <!-- 每个world允许包含1或n个database -->
+    <xs:sequence>
+      <xs:annotation>
+        <xs:documentation>世界中配置的数据库</xs:documentation>
+      </xs:annotation>
+      <xs:element name="database" type="databaseType" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+
+    <!-- world需要id和worldName -->
     <xs:attribute name="id" type="xs:unsignedInt" use="required">
       <xs:annotation>
         <xs:documentation>世界ID</xs:documentation>
@@ -137,27 +193,6 @@
       <xs:annotation>
         <xs:documentation>世界名称</xs:documentation>
       </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="dbConnection" type="xs:string" use="optional">
-      <xs:annotation>
-        <xs:documentation>数据库连接字符串</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="dbName" type="xs:string" use="required">
-      <xs:annotation>
-        <xs:documentation>数据库名称</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="dbType" use="required">
-      <xs:annotation>
-        <xs:documentation>数据库类型</xs:documentation>
-      </xs:annotation>
-      <xs:simpleType>
-        <xs:restriction base="xs:string">
-          <xs:enumeration value="MongoDB"/>
-          <xs:enumeration value="SQL"/>
-        </xs:restriction>
-      </xs:simpleType>
     </xs:attribute>
   </xs:complexType>
 
@@ -232,6 +267,40 @@
     </xs:attribute>
   </xs:complexType>
 
+  <!-- Network Runtime type -->
+  <xs:complexType name="networkRuntimeType">
+    <xs:attribute name="inner" use="optional" default="TCP">
+      <xs:annotation>
+        <xs:documentation>服务器内部网络协议</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="TCP"/>
+          <xs:enumeration value="KCP"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="maxMessageSize" type="xs:int" use="optional" default="1048560">
+      <xs:annotation>
+        <xs:documentation>消息体最大长度(字节)，默认1048560字节(约1.02MB)</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <!-- Session Runtime type -->
+  <xs:complexType name="sessionRuntimeType">
+    <xs:attribute name="idleTimeout" type="xs:int" use="optional" default="8000">
+      <xs:annotation>
+        <xs:documentation>Session idle check timeout (in milliseconds)</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="idleInterval" type="xs:int" use="optional" default="5000">
+      <xs:annotation>
+        <xs:documentation>Session idle check interval (in milliseconds)</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  
   <!-- Units types -->
   <xs:complexType name="unitsType">
     <xs:sequence>

--- a/examples/Server/Entity/Entity.csproj
+++ b/examples/Server/Entity/Entity.csproj
@@ -23,9 +23,7 @@
 
     <!-- Source Generator Reference -->
     <ItemGroup>
-      <ProjectReference Include="..\..\..\Fantasy.Net\Fantasy.SourceGenerator\Fantasy.SourceGenerator.csproj"
-                        OutputItemType="Analyzer"
-                        ReferenceOutputAssembly="false" />
+      <ProjectReference Include="..\..\..\Fantasy.Net\Fantasy.SourceGenerator\Fantasy.SourceGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
 </Project>

--- a/examples/Server/Entity/Model/DatabasesExample/FTableChild.cs
+++ b/examples/Server/Entity/Model/DatabasesExample/FTableChild.cs
@@ -1,0 +1,23 @@
+﻿using Fantasy.Database.Attributes;
+using Fantasy.Entitas;
+using Fantasy.Entitas.Interface;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fantasy
+{
+    //[FTable("ExampleComponent", Description = "Fantasy Table Test Child")]
+    public class FTableChild :Entity, ISupportedMultiEntity
+    {
+        public int TestIntField;
+
+        public int TestStringField;
+
+        [NotMapped]
+        public int NotMapped;
+    }
+}

--- a/examples/Server/Entity/Model/DatabasesExample/FTableComponentA.cs
+++ b/examples/Server/Entity/Model/DatabasesExample/FTableComponentA.cs
@@ -1,0 +1,17 @@
+﻿using Fantasy.Database.Attributes;
+using Fantasy.Entitas;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Fantasy
+{
+    //[FTable("ExampleComponentA", Description = "Fantasy Table Test Component")]
+    public class FTableComponentA : Entity
+    {
+        public int TestIntField;
+
+        public int TestStringField;
+
+        [NotMapped]
+        public int NotMapped;
+    }
+}

--- a/examples/Server/Entity/Model/DatabasesExample/FTableComponentB.cs
+++ b/examples/Server/Entity/Model/DatabasesExample/FTableComponentB.cs
@@ -1,0 +1,17 @@
+﻿using Fantasy.Database.Attributes;
+using Fantasy.Entitas;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Fantasy
+{
+    //[FTable("ExampleComponentB", Description = "Fantasy Table Test Component")]
+    public class FTableComponentB : Entity
+    {
+        public int TestIntField;
+
+        public int TestStringField;
+
+        [NotMapped]
+        public int NotMapped;
+    }
+}

--- a/examples/Server/Entity/Model/DatabasesExample/FTableComponentC.cs
+++ b/examples/Server/Entity/Model/DatabasesExample/FTableComponentC.cs
@@ -1,0 +1,17 @@
+﻿using Fantasy.Database.Attributes;
+using Fantasy.Entitas;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Fantasy
+{
+    //[FTable("ExampleComponentC", Description = "Fantasy Table Test Component")]
+    public class FTableComponentC : Entity
+    {
+        public int TestIntField;
+
+        public int TestStringField;
+
+        [NotMapped]
+        public int NotMapped;
+    }
+}

--- a/examples/Server/Entity/Model/DatabasesExample/FTableExampleRoot.cs
+++ b/examples/Server/Entity/Model/DatabasesExample/FTableExampleRoot.cs
@@ -1,0 +1,175 @@
+﻿using Fantasy.Async;
+using Fantasy.Database;
+using Fantasy.Database.Attributes;
+using Fantasy.Entitas;
+using Fantasy.Entitas.Interface;
+using Fantasy.Event;
+using MongoDB.Driver;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Fantasy
+{
+    public enum TestWhat
+    {
+        FastDeploy,
+        Init,
+        Insert,
+        Save,
+        Query,
+        QueryWithIndexes,
+        JoinQuery
+    }
+
+    [FTable("FTableExampleEntity", Description = "Fantasy Table Test root Entity")]
+    public class FTableExampleRoot : Entity
+    {
+        public int TestIntField;
+
+        public int TestStringField;
+
+        [NotMapped]
+        public int NotMapped;
+
+        public async FTask StartTest<T>(TestWhat testItem,int dutyId)where T:class,IDatabase 
+        {
+            var componentA = AddComponent<FTableComponentA>();
+            var componentB = AddComponent<FTableComponentB>();
+
+            var child01 = componentA.AddComponent<FTableChild>();
+            var child02 = componentA.AddComponent<FTableChild>();
+            var child03 = componentA.AddComponent<FTableChild>();
+
+            child01.AddComponent<FTableComponentA>();
+            child02.AddComponent<FTableComponentB>();
+
+            var componentC = child03.AddComponent<FTableComponentC>();
+            var grandChild = componentC.AddComponent<FTableGrandchild>();
+            grandChild.AddComponent<FTableComponentA>();
+            grandChild.AddComponent<FTableComponentB>();
+            grandChild.AddComponent<FTableComponentC>();
+
+            Log.Debug("[FTable] 测试: 实体树已构造,");
+            Log.Debug("\r\n        ///     Root\r\n        ///     ├─ ComponentA\r\n        ///     │  ├─ Child01\r\n        ///     │  │  └─ ComponentA\r\n        ///     │  ├─ Child02\r\n        ///     │  │  └─ ComponentB\r\n        ///     │  └─ Child03\r\n        ///     │     └─ ComponentC\r\n        ///     │        └─ Grandchild\r\n        ///     │           ├─ ComponentA\r\n        ///     │           ├─ ComponentB\r\n        ///     │           └─ ComponentC\r\n        ///     └─ ComponentB");
+
+            var db = Scene.World.GetDatabase<T>(dutyId);
+
+            if (db == null)
+            {
+                Log.Error($"{typeof(T)}不存在,无法进行测试");
+                return;
+            }
+
+            switch (testItem)
+            {
+                case TestWhat.FastDeploy:
+                {
+                    await db.FastDeploy();
+                    break;
+                }
+                case TestWhat.Insert:
+                {
+                        using var scope = db.Use(out IDbSession? dbSession);
+
+                        if (dbSession == null)
+                            throw new("Failed to use dbSession.");
+
+                        var entity = Entity.Create<FTableExampleRoot>(Scene, true, true);
+                        await dbSession.Save(entity, "FTableExampleEntity");
+                      
+                        break;
+                }
+                case TestWhat.Save:
+                {
+
+                    break;
+                }
+                case TestWhat.Query:
+                {
+
+                    break;
+                }
+                case TestWhat.QueryWithIndexes:
+                {
+
+                    break;
+                }
+                case TestWhat.JoinQuery:
+                {
+
+                    break;
+                }
+            }
+        }
+
+        public void TestAPI() {
+            if (Scene.SceneConfigId == 1001)
+            {
+                var mongo = Scene.World.GetDatabase<MongoDb>(2);
+                var pgSQL = Scene.World.GetDatabase<PostgreSQL>(0);
+
+                //if(mongo!=null)
+                //{
+                //    //mongo.开始测试(限流锁测试.信号量锁住Id).Coroutine();
+                //    mongo.开始测试(限流锁测试.信号量锁).Coroutine();
+                //    mongo.开始测试(限流锁测试.随机数锁).Coroutine();
+                //    //mongo.开始信号量锁有效性测试().Coroutine();
+                //}
+
+                if (pgSQL != null)
+                {
+                    Log.Debug("《 PgSQL API 大测试》");
+
+                    //using (pgSQL.Use(out IDbSession? session, useSessionFromPool: false))
+                    //{
+                    //    if (session == null)
+                    //        Log.Error($"( Failed to connect to PgSQL logic-database)\n ");
+                    //    else
+                    //        Log.Debug("已创建非池化的会话");
+                    //}
+
+                    //Log.Warning("↑看看非池化的会话有没有Dispose呢?");
+
+                    using (pgSQL.Use(out IDbSession? session, useSessionFromPool: true))
+                    {
+                        if (session == null)
+                            Log.Error($"( Failed to connect to PgSQL logic-database)\n ");
+                        else
+                            Log.Debug("已创建池化的会话");
+                    }
+
+                    Log.Warning("↑看看池化的会话有没有Dispose呢?");
+
+                    //using (pgSQL.Use(out PgSession? session, useSessionFromPool: false))
+                    //{
+                    //    if (session == null)
+                    //        Log.Error($"( Failed to connect to PgSQL logic-database)\n ");
+                    //    else
+                    //        Log.Debug("已创建PgSession强类型非池化会话");
+                    //}
+
+                    //Log.Warning("↑看看PgSession强类型非池化的会话有没有Dispose呢?");
+
+                    //using (pgSQL.Use(out PgSession? session, useSessionFromPool: true))
+                    //{
+                    //    if (session == null)
+                    //        Log.Error($"( Failed to connect to PgSQL logic-database)\n ");
+                    //    else
+                    //        Log.Debug("已创建池化的PgSession强类型会话");
+                    //}
+
+                    //Log.Warning("↑看看PgSession池化的强类型的会话有没有Dispose呢?");
+
+                    //await pgSQL.Invoke(async (session) =>
+                    //{
+                    //    if (session == null)
+                    //        Log.Error($"( Failed to connect to PgSQL logic-database)\n ");
+                    //    else
+                    //        Log.Debug("Invoke测试(Session默认池化)");
+                    //    await FTask.CompletedTask;
+                    //});
+                    //Log.Warning("↑看看Invoke的PgSession(默认池化)有没有Dispose呢?");
+                }
+            }
+        }
+    }
+}

--- a/examples/Server/Entity/Model/DatabasesExample/FTableGrandchild.cs
+++ b/examples/Server/Entity/Model/DatabasesExample/FTableGrandchild.cs
@@ -1,0 +1,20 @@
+﻿using Fantasy.Database.Attributes;
+using Fantasy.Entitas;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fantasy
+{
+    //[FTable("ExampleGrandchild", Description = "Fantasy Table Test Grandchild")]
+    public class FTableGrandchild : Entity
+    {
+        public int TestIntField;
+
+        public int TestStringField;
+
+        [NotMapped]
+        public int NotMapped;
+    }
+}

--- a/examples/Server/Hotfix/HTTPHandler/HelloController.cs
+++ b/examples/Server/Hotfix/HTTPHandler/HelloController.cs
@@ -26,6 +26,7 @@ public class HelloController : ControllerBase
     public async FTask<IActionResult> Greet()
     {
         Log.Debug($"HelloController Thread.CurrentThread.ManagedThreadId:{Thread.CurrentThread.ManagedThreadId}");
+        await FTask.CompletedTask;
         return Ok($"Hello from the Fantasy controller! _scene.SceneType:{_scene.SceneType} _scene.SceneType:{_scene.SceneConfigId}");
     }
 }

--- a/examples/Server/Hotfix/OnCreateSceneEvent.cs
+++ b/examples/Server/Hotfix/OnCreateSceneEvent.cs
@@ -1,6 +1,6 @@
 using Fantasy.Assembly;
 using Fantasy.Async;
-using Fantasy.DataBase;
+using Fantasy.Database;
 using Fantasy.Entitas;
 using Fantasy.Entitas.Interface;
 using Fantasy.Event;
@@ -77,7 +77,9 @@ public sealed class OnCreateSceneEvent : AsyncEventSystem<OnCreateScene>
         //     Log.Debug($"time = {time} now = {now} epochThisYear = {epochThisYear}");
         // }
         var scene = self.Scene;
-        
+
+        await FTask.CompletedTask;
+
         switch (scene.SceneType)
         {
             case 6666:
@@ -135,6 +137,13 @@ public sealed class OnCreateSceneEvent : AsyncEventSystem<OnCreateScene>
             }
         }
 
-        await FTask.CompletedTask;
+        //测试FTable
+        if (scene.SceneConfigId == 1001)
+        {
+            var TestFTableRoot =  scene.AddComponent<FTableExampleRoot>();
+            //TestFTableRoot.StartTest<PostgreSQL>(TestWhat.FastDeploy, dutyId: 0).Coroutine();
+            //TestFTableRoot.StartTest<MongoDb>(TestWhat.FastDeploy, dutyId: 2).Coroutine();
+            //TestFTableRoot.StartTest<MongoDb>(TestWhat.Insert, dutyId: 2).Coroutine();
+        }       
     }
 }

--- a/examples/Server/Main/Fantasy.config
+++ b/examples/Server/Main/Fantasy.config
@@ -2,23 +2,38 @@
 <fantasy xmlns="http://fantasy.net/config" 
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://fantasy.net/config Fantasy.xsd">
-    <!-- ~1~ 兼容模式：继续使用JSON配置表 @1@ -->
-    <!-- <configTable path="./../../../Config/Json/Server/" /> -->
-    <!-- 框架核心配置 -->
-    <idFactory type="World" />
-    <network inner="TCP" maxMessageSize="1048560" />
-    <session idleTimeout="8000" idleInterval="5000" />
-    <!-- 服务器拓扑结构 -->
-    <server>
+  
+  <!-- ↓这是为了兼容旧版Fantasy的导表Json配置↓, 如果这个XML节点被注释掉, 就会以 Fantasy.config 配置为准 -->
+  <!--<configTable path="../../../../Config/Json/Server" />-->
+
+  <!-- ↓这是目前推荐使用的Fantasy框架启服配置↓ -->
+
+  <network inner="TCP" maxMessageSize="1048560" />
+  <session idleTimeout="8000" idleInterval="5000" />
+  <server>
+    <!-- 机器配置 -->
     <machines>
       <machine id="1" outerIP="127.0.0.1" outerBindIP="127.0.0.1" innerBindIP="127.0.0.1" />
     </machines>
+    
+    <!-- 进程配置 -->
     <processes>
       <process id="1" machineId="1" startupGroup="0" />
     </processes>
+
+    <!-- 世界配置 -->
     <worlds>
-      <world id="1" worldName="测试服" dbConnection="" dbName="fantasy_main" dbType="MongoDB" />
+      <world id="1" worldName="WorldA">  <!-- 示范↓可在一个世界中配置多个数据库, 如果 dbConnection 设置为空 自动忽视 -->
+        <database duty="0" dbType="PgSQL" dbName="master" dbConnection="Host=localhost;Port=5432;Database=master;Username=postgres;Password=147369" />
+        <database duty="1" dbType="PgSQL" dbName="replica" dbConnection="" />
+        <database duty="2" dbType="MongoDB" dbName="doc" dbConnection="mongodb://localhost:27017/"/>
+      </world>
+      <world id="2" worldName="WorldB"> 
+        <database duty="0" dbType="MongoDB" dbName="doc" dbConnection=""/>
+      </world>
     </worlds>
+
+    <!-- 场景配置 -->
     <scenes>
       <scene id="1001" processConfigId="1" worldConfigId="1" sceneRuntimeMode="MultiThread" 
              sceneTypeString="Addressable" networkProtocol="" outerPort="0" innerPort="11001" sceneType="2" />
@@ -28,8 +43,18 @@
              sceneTypeString="Map" networkProtocol="" outerPort="0" innerPort="11003" sceneType="4" />
       <scene id="1004" processConfigId="1" worldConfigId="1" sceneRuntimeMode="MultiThread" 
              sceneTypeString="Chat" networkProtocol="" outerPort="0" innerPort="11004" sceneType="8" />
-      <scene id="1005" processConfigId="1" worldConfigId="1" sceneRuntimeMode="MultiThread" 
+      <scene id="2001" processConfigId="1" worldConfigId="2" sceneRuntimeMode="MultiThread" 
              sceneTypeString="Map" networkProtocol="" outerPort="0" innerPort="11005" sceneType="4" />
     </scenes>
+    
+    <!-- 单位配置 -->
+    <units>
+      <unit id="1" name="Unit01" model="Unit01">
+        <dic>
+          <item key="1" value="Idle" />
+          <item key="2" value="Run" />
+        </dic>
+      </unit>
+    </units>
   </server>
 </fantasy>

--- a/examples/Server/Main/Fantasy.xsd
+++ b/examples/Server/Main/Fantasy.xsd
@@ -15,12 +15,7 @@
           <xs:annotation>
             <xs:documentation>配置表路径设置</xs:documentation>
           </xs:annotation>
-        </xs:element>
-        <xs:element name="idFactory" type="idFactoryType" minOccurs="0" maxOccurs="1">
-          <xs:annotation>
-            <xs:documentation>ID生成器配置</xs:documentation>
-          </xs:annotation>
-        </xs:element>
+        </xs:element>      
         <xs:element name="network" type="networkRuntimeType" minOccurs="0" maxOccurs="1">
           <xs:annotation>
             <xs:documentation>网络运行时配置</xs:documentation>
@@ -30,7 +25,7 @@
           <xs:annotation>
             <xs:documentation>会话运行时配置</xs:documentation>
           </xs:annotation>
-        </xs:element>
+        </xs:element>       
         <xs:element name="server" type="serverType" minOccurs="1" maxOccurs="1">
           <xs:annotation>
             <xs:documentation>服务器配置</xs:documentation>
@@ -49,28 +44,6 @@
     </xs:attribute>
   </xs:complexType>
 
-  <!-- IdFactory type -->
-  <xs:complexType name="idFactoryType">
-    <xs:attribute name="type" use="optional" default="World">
-      <xs:annotation>
-        <xs:documentation>ID生成器规则类型</xs:documentation>
-      </xs:annotation>
-      <xs:simpleType>
-        <xs:restriction base="xs:string">
-          <xs:enumeration value="Default">
-            <xs:annotation>
-              <xs:documentation>默认生成器，Scene最大为65535个</xs:documentation>
-            </xs:annotation>
-          </xs:enumeration>
-          <xs:enumeration value="World">
-            <xs:annotation>
-              <xs:documentation>ID中包含World，可解决合区ID重复问题，但Scene数量限制到255个</xs:documentation>
-            </xs:annotation>
-          </xs:enumeration>
-        </xs:restriction>
-      </xs:simpleType>
-    </xs:attribute>
-  </xs:complexType>
 
   <!-- Server type -->
   <xs:complexType name="serverType">
@@ -93,6 +66,11 @@
       <xs:element name="scenes" type="scenesType" minOccurs="0" maxOccurs="1">
         <xs:annotation>
           <xs:documentation>场景配置列表</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="units" type="unitsType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>单位配置列表</xs:documentation>
         </xs:annotation>
       </xs:element>
     </xs:sequence>
@@ -160,7 +138,53 @@
     </xs:sequence>
   </xs:complexType>
 
+  <!-- database的选择 -->
+  <xs:complexType name="databaseType">
+    <xs:attribute name="duty" type="xs:int" use="required">
+      <xs:annotation>
+        <xs:documentation>数据库的工作职责（ 比如主职、从职、日志职责等, 需自行约定不同 int 值）</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="dbType" use="required">
+      <xs:annotation>
+        <xs:documentation>数据库类型</xs:documentation>
+      </xs:annotation>
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <!-- PostgreSQL -->
+          <xs:enumeration value="PostgreSQL"/>
+          <xs:enumeration value="Postgres"/>
+          <xs:enumeration value="PgSQL"/>
+          <xs:enumeration value="Pg"/>
+          <xs:enumeration value="PG"/>
+          <!-- MongoDB -->
+          <xs:enumeration value="MongoDB"/>
+          <xs:enumeration value="Mongo"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+    <xs:attribute name="dbName" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>数据库名称</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="dbConnection" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>数据库连接字符串</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
   <xs:complexType name="worldType">
+    <!-- 每个world允许包含1或n个database -->
+    <xs:sequence>
+      <xs:annotation>
+        <xs:documentation>世界中配置的数据库</xs:documentation>
+      </xs:annotation>
+      <xs:element name="database" type="databaseType" minOccurs="1" maxOccurs="unbounded"/>
+    </xs:sequence>
+
+    <!-- world需要id和worldName -->
     <xs:attribute name="id" type="xs:unsignedInt" use="required">
       <xs:annotation>
         <xs:documentation>世界ID</xs:documentation>
@@ -170,27 +194,6 @@
       <xs:annotation>
         <xs:documentation>世界名称</xs:documentation>
       </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="dbConnection" type="xs:string" use="optional">
-      <xs:annotation>
-        <xs:documentation>数据库连接字符串</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="dbName" type="xs:string" use="required">
-      <xs:annotation>
-        <xs:documentation>数据库名称</xs:documentation>
-      </xs:annotation>
-    </xs:attribute>
-    <xs:attribute name="dbType" use="required">
-      <xs:annotation>
-        <xs:documentation>数据库类型</xs:documentation>
-      </xs:annotation>
-      <xs:simpleType>
-        <xs:restriction base="xs:string">
-          <xs:enumeration value="MongoDB"/>
-          <xs:enumeration value="SQL"/>
-        </xs:restriction>
-      </xs:simpleType>
     </xs:attribute>
   </xs:complexType>
 
@@ -297,6 +300,58 @@
         <xs:documentation>Session idle check interval (in milliseconds)</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+  </xs:complexType>
+  
+  
+  <!-- Units types -->
+  <xs:complexType name="unitsType">
+    <xs:sequence>
+      <xs:element name="unit" type="unitType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="unitType">
+    <xs:sequence>
+      <xs:element name="dic" type="unitDicType" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>单位字典数据</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:unsignedInt" use="required">
+      <xs:annotation>
+        <xs:documentation>单位ID</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="name" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>单位名称</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="model" type="xs:string" use="required">
+      <xs:annotation>
+        <xs:documentation>单位模型</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="unitDicType">
+    <xs:sequence>
+      <xs:element name="item" minOccurs="0" maxOccurs="unbounded">
+        <xs:complexType>
+          <xs:attribute name="key" type="xs:string" use="required">
+            <xs:annotation>
+              <xs:documentation>字典键</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+          <xs:attribute name="value" type="xs:string" use="required">
+            <xs:annotation>
+              <xs:documentation>字典值</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
   </xs:complexType>
 
 </xs:schema>


### PR DESCRIPTION
1. World - 支持同时使用多个数据库, 支持按不同 Duty(工作职责)、以强类型的方法操作不同数据库. 支持ServiceProvider依赖注入 (说明: SQL数据库的DbContextPool 天然需要微软的依赖注入才能使用, 遂在 World 中引入了ServiceProvider, 否则 DbContext 无法池化) ;

2. Fantasy.Config - 支持通过 WorldConfig 在一个World中进行多数据库的配置, 兼容初佬的 XML xsd 字符检测;

3. SQL - 支持强大的 PostgreSQL , 适用于为关系模型或事务性考量的业务 ( API位置: PostgreSQL. cs、PgSession. cs) ;

4. FTableAttribute - 用[FTable]这个标签设置要纳入SQL数据库的实体,用于构建 "实体 - 表" 的ORM映射模型;

5. 数据库访问层优化 - 将数据库Deploy (部署) 相关的方法 (比如操作Scheme的方法) ,与 CURD 相关的方法分离为IDatabase和IDbSession。并且加了3个API: FastDeploy (快速部署)、DropEverything（清空逻辑数据库）、FastCount (快速计数);

6. MongoDb - CRUD的API几乎没有变化, 但是为了跟SQL统一入口, 将数据库操作API放入 MongoSession,通过Use()方法操作。使用的时候依然链式调用: MongoDb.Use().Query<>();

7. ICoroutineLock - 协程锁的抽象, 方便拓展锁的类型;

8. FTaskFlowLock - 任务限流锁, 代替之前 Mongo数据库操作API 当中大量直接使用生成随机数给协程上锁的做法, 优化可读性、可监控性, 避免随机数重复的问题;

9. CoroutineLock 可读性提升 - CoroutineLockType 有点太长了, 而且容易让人误会为这是"协程锁的类型", 可实际上它是"锁的用途", 可读性不佳,  改为 LockDuty (锁的职责), 用于描述"这个锁负责什么"的内涵; coroutineLockQueueKey 也是, 太长了, 变更为 waitForId (所等的Id)。

10. CoroutineLockFrozen (待完成) - 冻结态协程锁, 比普通协程锁寻值速度更快, 利用.NET8的FrozenDictionary;

11. 命名变更 - DataBase 勘误,Database才是"数据库" 而 DataBase可以理解为 "数据的基座" ;

12. 命名变更 -  用CreateDbSet替换原本接口中的 CreateDB 方法 (因其具有误导性), MongoDB依然可用该方法, 但PgSQL不允许使用。因为SQL式数据库不鼓励运行时动态建表 ( 要建表或更新表应该走"SQL数据库迁移流程") 。详情在PgSession的CreateDbSet中作了注释说明;

13. 命名变更 - Config初始化区分InitializeFromJson 和 Initialize;

14. 命名变更 - GetDataBaseInstance太长， 改为 RawHandler, 以强类型方式获取.