### PR TITLE
IPAddress 类型的序列化支持 + 协议工具自定义文本内容增强

### DIFF
--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Serialize/Pack/BsonPack/BsonPackNet.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Serialize/Pack/BsonPack/BsonPackNet.cs
@@ -1,5 +1,6 @@
 #if FANTASY_NET
 using System.Buffers;
+using System.Net;
 using Fantasy.Assembly;
 using Fantasy.Async;
 using Fantasy.Entitas;
@@ -31,6 +32,7 @@ namespace Fantasy.Serialize
         {
             BsonSerializer.RegisterSerializer(typeof(EntityTreeCollection), new EntityTreeCollectionSerializer());
             BsonSerializer.RegisterSerializer(typeof(EntityMultiCollection), new EntityMultiCollectionSerializer());
+            BsonSerializer.RegisterSerializer(typeof(IPAddress), new IPAddressSerializer());
             // 初始化 ConventionRegistry，注册 IgnoreExtraElements 约定，忽略反序列化时多余的字段
             ConventionRegistry.Register("IgnoreExtraElements",
                 new ConventionPack { new IgnoreExtraElementsConvention(true) }, type => true);

--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Serialize/Pack/BsonPack/BsonSerializer/IPAddressSerializer.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Serialize/Pack/BsonPack/BsonSerializer/IPAddressSerializer.cs
@@ -1,0 +1,26 @@
+﻿#if FANTASY_NET
+using System.Net;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace Fantasy.Serialize
+{
+    public class IPAddressSerializer : SerializerBase<IPAddress>
+    {
+        public override void Serialize(
+            BsonSerializationContext context,
+            BsonSerializationArgs args,
+            IPAddress value)
+        {
+            context.Writer.WriteString(value.ToString());
+        }
+
+        public override IPAddress Deserialize(
+            BsonDeserializationContext context,
+            BsonDeserializationArgs args)
+        {
+            return IPAddress.Parse(context.Reader.ReadString());
+        }
+    }
+}
+#endif

--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Serialize/Pack/MemoryPack/Formatter/IPAddressFormatter.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Serialize/Pack/MemoryPack/Formatter/IPAddressFormatter.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Runtime.InteropServices;
+using Fantasy;
+using MemoryPack;
+
+public sealed class IPAddressFormatter : MemoryPackFormatter<IPAddress>
+{
+#if FANTASY_UNITY
+    public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref IPAddress? value)
+#else
+    public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref IPAddress? value)
+#endif
+    {
+        if (value == null)
+        {
+            writer.WriteUnmanaged((byte)0); // null flag
+            return;
+        }
+
+        writer.WriteUnmanaged((byte)1); // not null
+
+        byte[] bytes = value.GetAddressBytes();
+        writer.WriteUnmanagedSpan(bytes.AsSpan());
+    }
+
+#if FANTASY_UNITY
+    public override void Deserialize(ref MemoryPackReader reader, ref IPAddress? value)
+#else
+    public override void Deserialize(ref MemoryPackReader reader, scoped ref IPAddress? value)
+#endif
+    {
+        byte nullFlag = reader.ReadUnmanaged<byte>();
+        if (nullFlag == 0)
+        {
+            value = null;
+            return;
+        }
+
+        if (!reader.TryReadCollectionHeader(out int length))
+            throw new MemoryPackSerializationException("Invalid IP header");
+
+        if (length != 4 && length != 16)
+            throw new MemoryPackSerializationException($"Invalid IP length: {length}");
+
+        ref byte spanRef = ref reader.GetSpanReference(length);
+        ReadOnlySpan<byte> span = MemoryMarshal.CreateReadOnlySpan(ref spanRef, length);
+
+        value = new IPAddress(span);
+        reader.Advance(length);
+    }
+}
+
+/// <summary>
+/// 测试IPAddress序列化与反序列化
+/// </summary>
+public static class MemoryPackIPAdressTest
+{
+    public static void Run()
+    {
+        var list = new List<IPAddress>
+        {
+            IPAddress.Parse("127.0.0.1"),
+            IPAddress.Parse("192.168.1.1")
+        };
+
+        Log.Debug("===== ORIGINAL =====");
+        foreach (var ip in list)
+        {
+            Log.Debug(ip.ToString());
+        }
+
+        // 序列化
+        var bytes = MemoryPackSerializer.Serialize(list);
+
+        Log.Debug("===== SERIALIZED BYTES =====");
+        Log.Debug("Length: " + bytes.Length);
+        Log.Debug(BitConverter.ToString(bytes));
+
+        // 反序列化
+        var result = MemoryPackSerializer.Deserialize<List<IPAddress>>(bytes);
+
+        Log.Debug("===== DESERIALIZED =====");
+        if (result == null)
+        {
+            Log.Debug("Result is NULL");
+            return;
+        }
+
+        foreach (var ip in result)
+        {
+            Log.Debug(ip.ToString());
+        }
+    }
+}

--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Serialize/Pack/MemoryPack/MemoryPackHelper.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Serialize/Pack/MemoryPack/MemoryPackHelper.cs
@@ -52,6 +52,7 @@ namespace Fantasy.Serialize
             MemoryPackFormatterProvider.Register(new EntityFormatter());
             MemoryPackFormatterProvider.Register(new EntityTreeCollectionFormatter());
             MemoryPackFormatterProvider.Register(new EntityMultiCollectionFormatter());
+            MemoryPackFormatterProvider.Register(new IPAddressFormatter());
             await AssemblyLifecycle.Add(this);
             return this;
         }

--- a/Fantasy.Packages/Fantasy.ProtocolExportTool/Generators/CSharpExporter.cs
+++ b/Fantasy.Packages/Fantasy.ProtocolExportTool/Generators/CSharpExporter.cs
@@ -251,8 +251,9 @@ public sealed class CSharpExporter(
                             if (messageDefinition.Fields.Count > 0)
                             {
                                 var parameters = string.Join(", ",
-                                    messageDefinition.Fields.Select(f =>
-                                        $"{ConvertType(f)} {char.ToLower(f.Name[0])}{f.Name[1..]}"));
+                                    messageDefinition.Fields
+                                    .Where(f => f.CustomTextLine == null) // 跳过自定义文本行
+                                    .Select(f => $"{ConvertType(f)} {char.ToLower(f.Name[0])}{f.Name[1..]}"));
                                 helper.AppendLine("\t\t[MethodImpl(MethodImplOptions.AggressiveInlining)]");
                                 helper.AppendLine($"\t\tpublic static void {messageDefinitionName}(this Session session, {parameters})");
                                 helper.AppendLine("\t\t{");
@@ -260,6 +261,8 @@ public sealed class CSharpExporter(
 
                                 foreach (var field in messageDefinition.Fields)
                                 {
+                                    if (field.CustomTextLine != null) // 跳过自定义文本行
+                                        continue;
                                     helper.AppendLine($"\t\t\t{messageDefinitionName}_message.{field.Name} = {char.ToLower(field.Name[0])}{field.Name[1..]};");
                                 }
 
@@ -291,7 +294,9 @@ public sealed class CSharpExporter(
                             if (messageDefinition.Fields.Count > 0)
                             {
                                 var parameters = string.Join(", ",
-                                    messageDefinition.Fields.Select(f =>
+                                    messageDefinition.Fields
+                                    .Where(f => f.CustomTextLine == null) // 跳过自定义文本行
+                                    .Select(f =>
                                         $"{ConvertType(f)} {char.ToLower(f.Name[0])}{f.Name[1..]}"));
                                 helper.AppendLine($"\t\t[MethodImpl(MethodImplOptions.AggressiveInlining)]");
                                 helper.AppendLine($"\t\tpublic static async FTask<{messageDefinition.ResponseType}> {messageDefinitionName}(this Session session, {parameters})");
@@ -299,6 +304,8 @@ public sealed class CSharpExporter(
                                 helper.AppendLine($"\t\t\tusing var {messageDefinitionName}_request = Fantasy.{messageDefinitionName}.Create();");
                                 foreach (var field in messageDefinition.Fields)
                                 {
+                                    if (field.CustomTextLine != null) // 跳过自定义文本行
+                                        continue;
                                     helper.AppendLine($"\t\t\t{messageDefinitionName}_request.{field.Name} = {char.ToLower(field.Name[0])}{field.Name[1..]};");
                                 }
                                 helper.AppendLine($"\t\t\treturn ({messageDefinition.ResponseType})await session.Call({messageDefinitionName}_request);");
@@ -422,6 +429,12 @@ public sealed class CSharpExporter(
             
             foreach (var field in messageDefinition.Fields)
             {
+                if(field.CustomTextLine != null) // 直接输出自定义文本行
+                {
+                    members.Add(field.CustomTextLine);
+                    continue;
+                }
+
                 string? disposeStatement;
                 switch (field.CollectionType)
                 {

--- a/Fantasy.Packages/Fantasy.ProtocolExportTool/Generators/Parsers/ProtocolFileParser.cs
+++ b/Fantasy.Packages/Fantasy.ProtocolExportTool/Generators/Parsers/ProtocolFileParser.cs
@@ -18,7 +18,7 @@ public struct ParseResult
     public HashSet<string> Namespaces { get; init; } = new();
     public List<EnumDefinition> Enums { get; init; } = new();
     public Dictionary<string, MessageDefinition> Messages { get; init; } = new();
-    
+
     public ParseResult(HashSet<string> namespaces, Dictionary<string, MessageDefinition> messages, List<EnumDefinition> enums)
     {
         Namespaces = namespaces;
@@ -42,23 +42,23 @@ public sealed partial class ProtocolFileParser(string filePath)
     private int _currentKeyIndex = 1;
     private readonly List<string> _pendingComments = new();
     private readonly List<string> _defineConstants = new();
-    
+
     /// <summary>
-    /// 字段解析正则表达式: type name = number, 支持中日韩等非英文字符
+    /// 字段解析正则表达式: type name = number, 支持中日韩等非英文字符, 支持C#的可空符号:?
     /// </summary>
-    [GeneratedRegex(@"^\s*([\p{L}_][\p{L}\p{N}_]*)\s+([\p{L}_][\p{L}\p{N}_]*)\s*=\s*(\d+)\s*;$")]
+    [GeneratedRegex(@"^\s*([\p{L}_][\p{L}\p{N}_]*\??)\s+([\p{L}_][\p{L}\p{N}_]*)\s*=\s*(\d+)\s*;$")]
     private static partial Regex FieldRegex();
 
     /// <summary>
-    /// 枚举值解析正则表达式: Name = Value 或 Name, 支持中日韩等非英文字符
+    /// 枚举值解析正则表达式: Name = Value 或 Name, 支持中日韩等非英文字符, 支持C#的可空符号:?
     /// </summary>
-    [GeneratedRegex(@"^\s*([\p{L}_][\p{L}\p{N}_]*)(?:\s*=\s*(\d+))?\s*$")]
+    [GeneratedRegex(@"^\s*([\p{L}_][\p{L}\p{N}_]*\??)(?:\s*=\s*(\d+))?\s*$")]
     private static partial Regex EnumValueRegex();
 
     /// <summary>
-    /// Map 字段名称和编号解析正则表达式: name = number, 支持中日韩等非英文字符
+    /// Map 字段名称和编号解析正则表达式: name = number, 支持中日韩等非英文字符, 支持C#的可空符号:?
     /// </summary>
-    [GeneratedRegex(@"^\s*([\p{L}_][\p{L}\p{N}_]*)\s*=\s*(\d+)\s*;$")]
+    [GeneratedRegex(@"^\s*([\p{L}_][\p{L}\p{N}_]*\??)\s*=\s*(\d+)\s*;$")]
     private static partial Regex MapFieldRegex();
 
     /// <summary>
@@ -69,7 +69,7 @@ public sealed partial class ProtocolFileParser(string filePath)
         var namespaces = new HashSet<string>();
         var enums = new List<EnumDefinition>();
         var messages = new Dictionary<string, MessageDefinition>();
-        
+
         for (var i = 0; i < lines.Length; i++)
         {
             var line = lines[i].Trim();
@@ -266,77 +266,77 @@ public sealed partial class ProtocolFileParser(string filePath)
             {
                 return message;
             }
-            
+
             message.InterfaceType = parameters[0];
 
             switch (parameters.Length)
             {
                 case 1:
-                {
-                    if (message.InterfaceType.Contains("IResponse") ||
-                        message.InterfaceType.Contains("IAddressableResponse") ||
-                        message.InterfaceType.Contains("IAddressResponse"))
                     {
-                        message.MessageType = MessageType.Response;
+                        if (message.InterfaceType.Contains("IResponse") ||
+                            message.InterfaceType.Contains("IAddressableResponse") ||
+                            message.InterfaceType.Contains("IAddressResponse"))
+                        {
+                            message.MessageType = MessageType.Response;
+                        }
+                        else if (message.InterfaceType.Contains("ICustomRouteResponse"))
+                        {
+                            message.MessageType = MessageType.RouteTypeResponse;
+                        }
+                        else if (message.InterfaceType.Contains("IRoamingResponse"))
+                        {
+                            message.MessageType = MessageType.RoamingResponse;
+                        }
+                        else if (message.InterfaceType.Contains("IMessage") ||
+                                message.InterfaceType.Contains("IAddressableMessage") ||
+                                message.InterfaceType.Contains("IAddressMessage"))
+                        {
+                            message.MessageType = MessageType.Message;
+                        }
+                        break;
                     }
-                    else if (message.InterfaceType.Contains("ICustomRouteResponse"))
-                    {
-                        message.MessageType = MessageType.RouteTypeResponse;
-                    }
-                    else if (message.InterfaceType.Contains("IRoamingResponse"))
-                    {
-                        message.MessageType = MessageType.RoamingResponse;
-                    }
-                    else if(message.InterfaceType.Contains("IMessage") || 
-                            message.InterfaceType.Contains("IAddressableMessage") ||
-                            message.InterfaceType.Contains("IAddressMessage"))
-                    {
-                        message.MessageType = MessageType.Message;
-                    }
-                    break;
-                }
                 case 2:
-                {
-                    var secondParam = parameters[1];
-                    
-                    if (message.InterfaceType.Contains("ICustomRouteMessage"))
                     {
-                        message.MessageType = MessageType.RouteTypeMessage;
-                        message.CustomRouteType = $"Fantasy.RouteType.{secondParam}";
+                        var secondParam = parameters[1];
+
+                        if (message.InterfaceType.Contains("ICustomRouteMessage"))
+                        {
+                            message.MessageType = MessageType.RouteTypeMessage;
+                            message.CustomRouteType = $"Fantasy.RouteType.{secondParam}";
+                        }
+                        else if (message.InterfaceType.Contains("IRoamingMessage"))
+                        {
+                            message.MessageType = MessageType.RoamingMessage;
+                            message.CustomRouteType = $"Fantasy.RoamingType.{secondParam}";
+                        }
+                        else if (message.InterfaceType.Contains("IRequest") ||
+                                 message.InterfaceType.Contains("IAddressableRequest") ||
+                                 message.InterfaceType.Contains("IAddressRequest"))
+                        {
+                            message.MessageType = MessageType.Request;
+                            message.ResponseType = secondParam;
+                        }
+                        break;
                     }
-                    else if (message.InterfaceType.Contains("IRoamingMessage"))
-                    {
-                        message.MessageType = MessageType.RoamingMessage;
-                        message.CustomRouteType = $"Fantasy.RoamingType.{secondParam}";
-                    }
-                    else if (message.InterfaceType.Contains("IRequest") ||
-                             message.InterfaceType.Contains("IAddressableRequest") ||
-                             message.InterfaceType.Contains("IAddressRequest"))
-                    {
-                        message.MessageType = MessageType.Request;
-                        message.ResponseType = secondParam;
-                    }
-                    break;
-                }
                 case 3:
-                {
-                    var secondParam = parameters[1];
-                    var thirdParam = parameters[2];
-                    
-                    if (message.InterfaceType.Contains("ICustomRouteRequest"))
                     {
-                        message.MessageType = MessageType.RouteTypeRequest;
-                        message.ResponseType = secondParam;
-                        message.CustomRouteType = $"Fantasy.RouteType.{thirdParam}";
+                        var secondParam = parameters[1];
+                        var thirdParam = parameters[2];
+
+                        if (message.InterfaceType.Contains("ICustomRouteRequest"))
+                        {
+                            message.MessageType = MessageType.RouteTypeRequest;
+                            message.ResponseType = secondParam;
+                            message.CustomRouteType = $"Fantasy.RouteType.{thirdParam}";
+                        }
+                        else if (message.InterfaceType.Contains("IRoamingRequest"))
+                        {
+                            message.MessageType = MessageType.RoamingRequest;
+                            message.ResponseType = secondParam;
+                            message.CustomRouteType = $"Fantasy.RoamingType.{thirdParam}";
+                        }
+                        break;
                     }
-                    else if (message.InterfaceType.Contains("IRoamingRequest"))
-                    {
-                        message.MessageType = MessageType.RoamingRequest;
-                        message.ResponseType = secondParam;
-                        message.CustomRouteType = $"Fantasy.RoamingType.{thirdParam}";
-                    }
-                    break;
-                }
             }
         }
 
@@ -363,7 +363,7 @@ public sealed partial class ProtocolFileParser(string filePath)
 
         // 提取行尾的 /// 注释
         var commentIndex = line.IndexOf("///", StringComparison.Ordinal);
-        
+
         if (commentIndex > 0)
         {
             var inlineComment = line.Substring(commentIndex + 3).Trim();
@@ -405,7 +405,7 @@ public sealed partial class ProtocolFileParser(string filePath)
         {
             field = ParseBytesField(line, lineNumber);
         }
-        else 
+        else
         {
             field = ParseRegularField(line, lineNumber);
         }
@@ -415,7 +415,8 @@ public sealed partial class ProtocolFileParser(string filePath)
             EndField(field, new List<string>(_pendingComments));
         }
 
-        void EndField(FieldDefinition field, List<string> documentationComments = null) {
+        void EndField(FieldDefinition field, List<string> documentationComments = null)
+        {
             field.KeyIndex = _currentKeyIndex++;
             field.DocumentationComments = documentationComments;
             _currentMessage.Fields.Add(field);
@@ -459,7 +460,7 @@ public sealed partial class ProtocolFileParser(string filePath)
         // 格式: bytes Data = 1;
         // var content = line.Substring("bytes".Length).Trim();
         var match = FieldRegex().Match(line);
-        
+
         if (!match.Success)
         {
             _errors.Add($"[red]  {filePath} line {lineNumber}: Invalid bytes field format: {Markup.Escape(line)}[/]");

--- a/Fantasy.Packages/Fantasy.ProtocolExportTool/Generators/Parsers/ProtocolFileParser.cs
+++ b/Fantasy.Packages/Fantasy.ProtocolExportTool/Generators/Parsers/ProtocolFileParser.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Sockets;
 using System.Text.RegularExpressions;
 using Fantasy.Network;
 using Fantasy.ProtocolExportTool.Models;
@@ -352,6 +353,14 @@ public sealed partial class ProtocolFileParser(string filePath)
             return;
         }
 
+        // 优先解析自定义文本行
+        var meybe_custom_text = TryParseCustomTextLineOnField(line);
+        if (meybe_custom_text != null)
+        {
+            EndField(meybe_custom_text);
+            return;
+        }
+
         // 提取行尾的 /// 注释
         var commentIndex = line.IndexOf("///", StringComparison.Ordinal);
         
@@ -403,8 +412,12 @@ public sealed partial class ProtocolFileParser(string filePath)
 
         if (field != null)
         {
+            EndField(field, new List<string>(_pendingComments));
+        }
+
+        void EndField(FieldDefinition field, List<string> documentationComments = null) {
             field.KeyIndex = _currentKeyIndex++;
-            field.DocumentationComments = new List<string>(_pendingComments);
+            field.DocumentationComments = documentationComments;
             _currentMessage.Fields.Add(field);
             _pendingComments.Clear();
         }
@@ -485,6 +498,27 @@ public sealed partial class ProtocolFileParser(string filePath)
             FieldNumber = int.Parse(match.Groups[3].Value),
             CollectionType = FieldCollectionType.Normal,
             SourceLineNumber = lineNumber
+        };
+    }
+
+    /// <summary>
+    /// 解析字段级的自定义文本行, 未解析成功返回null
+    /// 以给定的<see cref="FieldCustomTextLineKeyword"/>关键字开头的即判定为字段级自定义文本行。
+    /// </summary>
+    public const string FieldCustomTextLineKeyword = "#";
+    private FieldDefinition? TryParseCustomTextLineOnField(string line)
+    {
+        ReadOnlySpan<char> span = line.AsSpan();
+        if (!span.StartsWith(FieldCustomTextLineKeyword))
+        {
+            return null;
+        }
+        span = span.Slice(1);
+        string result = span.ToString();
+
+        return new FieldDefinition
+        {
+            CustomTextLine = result
         };
     }
 

--- a/Fantasy.Packages/Fantasy.ProtocolExportTool/Generators/Validators/ProtocolValidator.cs
+++ b/Fantasy.Packages/Fantasy.ProtocolExportTool/Generators/Validators/ProtocolValidator.cs
@@ -126,6 +126,9 @@ public sealed class ProtocolValidator
 
         foreach (var field in message.Fields)
         {
+            if (field.CustomTextLine != null) // 跳过自定义文本行
+                continue;
+
             // 验证字段名唯一性
             if (!fieldNames.Add(field.Name))
             {

--- a/Fantasy.Packages/Fantasy.ProtocolExportTool/Models/FieldDefinition.cs
+++ b/Fantasy.Packages/Fantasy.ProtocolExportTool/Models/FieldDefinition.cs
@@ -9,6 +9,11 @@ namespace Fantasy.ProtocolExportTool.Models;
 public sealed class FieldDefinition
 {
     /// <summary>
+    /// 自定义文本行
+    /// </summary>
+    public string? CustomTextLine { get; set; } = default;
+
+    /// <summary>
     /// 字段名称
     /// </summary>
     public string Name { get; set; } = string.Empty;

--- a/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Serialize/Pack/BsonPack/BsonPackNet.cs
+++ b/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Serialize/Pack/BsonPack/BsonPackNet.cs
@@ -1,5 +1,6 @@
 #if FANTASY_NET
 using System.Buffers;
+using System.Net;
 using Fantasy.Assembly;
 using Fantasy.Async;
 using Fantasy.Entitas;
@@ -31,6 +32,7 @@ namespace Fantasy.Serialize
         {
             BsonSerializer.RegisterSerializer(typeof(EntityTreeCollection), new EntityTreeCollectionSerializer());
             BsonSerializer.RegisterSerializer(typeof(EntityMultiCollection), new EntityMultiCollectionSerializer());
+            BsonSerializer.RegisterSerializer(typeof(IPAddress), new IPAddressSerializer());
             // 初始化 ConventionRegistry，注册 IgnoreExtraElements 约定，忽略反序列化时多余的字段
             ConventionRegistry.Register("IgnoreExtraElements",
                 new ConventionPack { new IgnoreExtraElementsConvention(true) }, type => true);

--- a/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Serialize/Pack/BsonPack/BsonSerializer/IPAddressSerializer.cs
+++ b/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Serialize/Pack/BsonPack/BsonSerializer/IPAddressSerializer.cs
@@ -1,0 +1,26 @@
+﻿#if FANTASY_NET
+using System.Net;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace Fantasy.Serialize
+{
+    public class IPAddressSerializer : SerializerBase<IPAddress>
+    {
+        public override void Serialize(
+            BsonSerializationContext context,
+            BsonSerializationArgs args,
+            IPAddress value)
+        {
+            context.Writer.WriteString(value.ToString());
+        }
+
+        public override IPAddress Deserialize(
+            BsonDeserializationContext context,
+            BsonDeserializationArgs args)
+        {
+            return IPAddress.Parse(context.Reader.ReadString());
+        }
+    }
+}
+#endif

--- a/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Serialize/Pack/BsonPack/BsonSerializer/IPAddressSerializer.cs.meta
+++ b/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Serialize/Pack/BsonPack/BsonSerializer/IPAddressSerializer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 45f6a7a00a6a792479d9907e6de1a6bc

--- a/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Serialize/Pack/MemoryPack/Formatter/IPAddressFormatter.cs
+++ b/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Serialize/Pack/MemoryPack/Formatter/IPAddressFormatter.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Runtime.InteropServices;
+using Fantasy;
+using MemoryPack;
+
+public sealed class IPAddressFormatter : MemoryPackFormatter<IPAddress>
+{
+#if FANTASY_UNITY
+    public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, ref IPAddress? value)
+#else
+    public override void Serialize<TBufferWriter>(ref MemoryPackWriter<TBufferWriter> writer, scoped ref IPAddress? value)
+#endif
+    {
+        if (value == null)
+        {
+            writer.WriteUnmanaged((byte)0); // null flag
+            return;
+        }
+
+        writer.WriteUnmanaged((byte)1); // not null
+
+        byte[] bytes = value.GetAddressBytes();
+        writer.WriteUnmanagedSpan(bytes.AsSpan());
+    }
+
+#if FANTASY_UNITY
+    public override void Deserialize(ref MemoryPackReader reader, ref IPAddress? value)
+#else
+    public override void Deserialize(ref MemoryPackReader reader, scoped ref IPAddress? value)
+#endif
+    {
+        byte nullFlag = reader.ReadUnmanaged<byte>();
+        if (nullFlag == 0)
+        {
+            value = null;
+            return;
+        }
+
+        if (!reader.TryReadCollectionHeader(out int length))
+            throw new MemoryPackSerializationException("Invalid IP header");
+
+        if (length != 4 && length != 16)
+            throw new MemoryPackSerializationException($"Invalid IP length: {length}");
+
+        ref byte spanRef = ref reader.GetSpanReference(length);
+        ReadOnlySpan<byte> span = MemoryMarshal.CreateReadOnlySpan(ref spanRef, length);
+
+        value = new IPAddress(span);
+        reader.Advance(length);
+    }
+}
+
+/// <summary>
+/// 测试IPAddress序列化与反序列化
+/// </summary>
+public static class MemoryPackIPAdressTest
+{
+    public static void Run()
+    {
+        var list = new List<IPAddress>
+        {
+            IPAddress.Parse("127.0.0.1"),
+            IPAddress.Parse("192.168.1.1")
+        };
+
+        Log.Debug("===== ORIGINAL =====");
+        foreach (var ip in list)
+        {
+            Log.Debug(ip.ToString());
+        }
+
+        // 序列化
+        var bytes = MemoryPackSerializer.Serialize(list);
+
+        Log.Debug("===== SERIALIZED BYTES =====");
+        Log.Debug("Length: " + bytes.Length);
+        Log.Debug(BitConverter.ToString(bytes));
+
+        // 反序列化
+        var result = MemoryPackSerializer.Deserialize<List<IPAddress>>(bytes);
+
+        Log.Debug("===== DESERIALIZED =====");
+        if (result == null)
+        {
+            Log.Debug("Result is NULL");
+            return;
+        }
+
+        foreach (var ip in result)
+        {
+            Log.Debug(ip.ToString());
+        }
+    }
+}

--- a/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Serialize/Pack/MemoryPack/Formatter/IPAddressFormatter.cs.meta
+++ b/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Serialize/Pack/MemoryPack/Formatter/IPAddressFormatter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ad2d440be52267f4985e92cd496bfa9c

--- a/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Serialize/Pack/MemoryPack/MemoryPackHelper.cs
+++ b/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Serialize/Pack/MemoryPack/MemoryPackHelper.cs
@@ -22,10 +22,10 @@ namespace Fantasy.Serialize
     {
         /// <inheritdoc/>
         public string SerializeName { get; } = "MemoryPack";
-        
+
         private static volatile Int64FrozenDictionary<Type> _types;
         private static readonly Int64MergerFrozenDictionary<Type> TypesMerger = new();
-        
+
         public static Int64FrozenDictionary<Type> TypeDictionary => _types;
 
         #region AssemblyManifest
@@ -40,7 +40,7 @@ namespace Fantasy.Serialize
             {
                 Interlocked.CompareExchange(
                     ref _types,
-                    new Int64FrozenDictionary<Type>(new long [1] { 1 }, new Type[1] { typeof(MemoryPackHelper) }),
+                    new Int64FrozenDictionary<Type>(new long[1] { 1 }, new Type[1] { typeof(MemoryPackHelper) }),
                     null);
             }
 #if FANTASY_UNITY
@@ -52,6 +52,7 @@ namespace Fantasy.Serialize
             MemoryPackFormatterProvider.Register(new EntityFormatter());
             MemoryPackFormatterProvider.Register(new EntityTreeCollectionFormatter());
             MemoryPackFormatterProvider.Register(new EntityMultiCollectionFormatter());
+            MemoryPackFormatterProvider.Register(new IPAddressFormatter());
             await AssemblyLifecycle.Add(this);
             return this;
         }
@@ -64,12 +65,12 @@ namespace Fantasy.Serialize
         {
             var memoryPackEntityGenerator = assemblyManifest.MemoryPackEntityGenerator;
             memoryPackEntityGenerator.Initialize();
-            
+
             if (!memoryPackEntityGenerator.EntityTypes().Any())
             {
                 return;
             }
-            
+
             if (ProgramDefine.IsAppRunning)
             {
                 var tcs = FTask.Create(false);
@@ -81,17 +82,17 @@ namespace Fantasy.Serialize
                 await tcs;
                 return;
             }
-            
+
             InnerOnLoad(assemblyManifest.AssemblyManifestId, memoryPackEntityGenerator);
         }
 
-        private void InnerOnLoad(long assemblyManifestId,IMemoryPackEntityGenerator memoryPackEntityGenerator)
+        private void InnerOnLoad(long assemblyManifestId, IMemoryPackEntityGenerator memoryPackEntityGenerator)
         {
             TypesMerger.Add(
                 assemblyManifestId,
                 memoryPackEntityGenerator.EntityTypeHashCodes(),
                 memoryPackEntityGenerator.EntityTypes());
-                
+
             Interlocked.Exchange(ref _types, TypesMerger.GetFrozenDictionary());
         }
 
@@ -103,7 +104,7 @@ namespace Fantasy.Serialize
         {
             var tcs = FTask.Create(false);
             var assemblyManifestId = assemblyManifest.AssemblyManifestId;
-            
+
             ThreadScheduler.MainScheduler.ThreadSynchronizationContext.Post(() =>
             {
                 if (TypesMerger.Remove(assemblyManifestId))
@@ -112,7 +113,7 @@ namespace Fantasy.Serialize
                 }
                 tcs.SetResult();
             });
-            
+
             return tcs;
         }
 

--- a/examples/Config/NetworkProtocol/Inner/InnerMessage.proto
+++ b/examples/Config/NetworkProtocol/Inner/InnerMessage.proto
@@ -13,6 +13,9 @@ package Sining.Message;
 // 通过添加 // using 导出时添加自定义命名空间
 // 例如: // using System.Runtime // using System.Reflection
 
+// 自定义文本: 在消息前使用////四道斜线按照原语句导出到类定义前;
+//            在消息内部使用 # 开头的按照原语句导出到消息属性声明前。
+
 message G2A_TestMessage // IAddressMessage
 {
 	string Tag = 1;

--- a/examples/Config/NetworkProtocol/Outer/OuterMessage.proto
+++ b/examples/Config/NetworkProtocol/Outer/OuterMessage.proto
@@ -13,6 +13,8 @@ package Fantasy.Network.Message;
 // 通过添加 // using 导出时添加自定义命名空间
 // 例如: // using System.Runtime // using System.Reflection
 
+// 自定义文本: 在消息前使用////四道斜线按照原语句导出到类定义前;
+//            在消息内部使用 # 开头的按照原语句导出到消息属性声明前。
 
 message C2G_TestEmptyMessage // IMessage
 {


### PR DESCRIPTION
1. 新增 IPAddress 的序列化和反序列化, 支持在消息对象、实体传送的过程中直接传输 IPAddress, 而无需手动转为 string 或 byte[] ；
2. 协议工具 支持通过 # 符号增加消息字段级别的自定义文本内容导出。