### PR TITLE
feat: 为协议导出工具添加MCP支持

### DIFF
--- a/Fantasy.Packages/Fantasy.ProtocolExportTool/Commands/McpServerCommand.cs
+++ b/Fantasy.Packages/Fantasy.ProtocolExportTool/Commands/McpServerCommand.cs
@@ -1,0 +1,474 @@
+using System;
+using System.CommandLine;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using Fantasy.ProtocolExportTool.Models;
+using Fantasy.ProtocolExportTool.Services;
+using Spectre.Console;
+
+namespace Fantasy.ProtocolExportTool.Commands;
+
+/// <summary>
+/// MCP服务器命令 - 使用JSON-RPC over stdio实现MCP协议
+/// </summary>
+public class McpServerCommand : Command
+{
+    private const string ConfigPathEnvVar = "FANTASY_PROTOCOL_CONFIG";
+
+    /// <summary>
+    /// 从命令行参数中解析DLL所在目录
+    /// 优先从命令行获取DLL路径，而不是使用Environment.ProcessPath（后者在MCP调用时不可靠）
+    /// </summary>
+    private static string GetDllDirectoryFromArgs(string[] args)
+    {
+        // 模式: dotnet "path/to/xxx.dll" mcp -c config.json
+        // 或: "path/to/xxx.dll" mcp -c config.json
+        
+        for (int i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            
+            // 跳过 "dotnet" 关键字
+            if (arg.Equals("dotnet", StringComparison.OrdinalIgnoreCase))
+                continue;
+                
+            // 跳过命令关键字
+            if (arg.Equals("mcp", StringComparison.OrdinalIgnoreCase) || arg.Equals("export", StringComparison.OrdinalIgnoreCase))
+                continue;
+                
+            // 跳过参数名
+            if (arg.Equals("-c", StringComparison.OrdinalIgnoreCase) || arg.Equals("--config", StringComparison.OrdinalIgnoreCase))
+                continue;
+                
+            // 检查是否是 DLL 文件
+            if (arg.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            {
+                // 检查文件是否存在
+                if (File.Exists(arg))
+                {
+                    return Path.GetDirectoryName(arg) ?? "";
+                }
+                
+                // 也可能是相对路径，检查工作目录下是否存在
+                var combined = Path.Combine(Directory.GetCurrentDirectory(), arg);
+                if (File.Exists(combined))
+                {
+                    return Path.GetDirectoryName(combined) ?? "";
+                }
+            }
+        }
+        
+        // 回退：使用当前工作目录
+        return Directory.GetCurrentDirectory();
+    }
+
+    public McpServerCommand() : base("mcp", "启动MCP服务器模式，允许远程调用协议导出")
+    {
+        var configPathOption = new Option<string>("-c", "--config")
+        {
+            Description = "配置文件路径",
+            DefaultValueFactory = _ => null
+        };
+
+        Add(configPathOption);
+
+        SetAction(async (parseResult, cancellationToken) =>
+        {
+            // 直接从 args 获取 DLL 目录
+            var args = parseResult.Tokens.Select(t => t.Value).ToArray();
+            var dllDir = GetDllDirectoryFromArgs(args);
+            
+            AnsiConsole.MarkupLine($"[gray]检测到DLL目录: {dllDir}[/]");
+
+            // 确定配置文件路径
+            string? configPath = null;
+            
+            // 1. 优先使用环境变量
+            var envConfigPath = Environment.GetEnvironmentVariable(ConfigPathEnvVar);
+            if (!string.IsNullOrEmpty(envConfigPath))
+            {
+                configPath = envConfigPath;
+                AnsiConsole.MarkupLine($"[green]✓[/] 使用环境变量配置: {ConfigPathEnvVar}={configPath}");
+            }
+            else
+            {
+                // 2. 检查 -c 参数
+                var cmdLineConfigPath = parseResult.GetValue(configPathOption);
+                if (!string.IsNullOrEmpty(cmdLineConfigPath))
+                {
+                    configPath = cmdLineConfigPath;
+                }
+                else
+                {
+                    // 3. 在DLL目录查找 ExporterSettings.json
+                    var defaultConfigPath = Path.Combine(dllDir, "ExporterSettings.json");
+                    if (File.Exists(defaultConfigPath))
+                    {
+                        configPath = defaultConfigPath;
+                        AnsiConsole.MarkupLine($"[green]✓[/] 使用DLL目录默认配置: {configPath}");
+                    }
+                }
+            }
+
+            // 如果没有找到配置文件
+            if (string.IsNullOrEmpty(configPath))
+            {
+                AnsiConsole.MarkupLine($"[red]错误:[/] 找不到配置文件。");
+                AnsiConsole.MarkupLine("[yellow]提示:[/] 请使用 -c 参数指定配置文件，或在DLL目录放置 ExporterSettings.json");
+                return 1;
+            }
+
+            // 检查配置文件是否存在
+            if (!File.Exists(configPath))
+            {
+                AnsiConsole.MarkupLine($"[red]错误:[/] 配置文件不存在: {configPath}");
+                return 1;
+            }
+
+            AnsiConsole.MarkupLine("[blue]╔════════════════════════════════════════════════╗[/]");
+            AnsiConsole.MarkupLine("[blue]║  Fantasy Protocol Export MCP Server            ║[/]");
+            AnsiConsole.MarkupLine("[blue]║  Version: 2026.0.1002                         ║[/]");
+            AnsiConsole.MarkupLine("[blue]╚════════════════════════════════════════════════╝[/]");
+            AnsiConsole.WriteLine();
+
+            // 加载配置（使用DLL目录作为基准）
+            var config = await ProtocolExportService.LoadConfigFromFileAsync(configPath, dllDir);
+            if (config == null)
+            {
+                return 1;
+            }
+
+            AnsiConsole.MarkupLine("[green]✓[/] 已加载配置文件");
+            AnsiConsole.MarkupLine($"  协议目录: {config.ProtocolDir}");
+            AnsiConsole.MarkupLine($"  服务器目录: {config.ServerDir}");
+            AnsiConsole.MarkupLine($"  客户端目录: {config.ClientDir}");
+            AnsiConsole.WriteLine();
+
+            // 首次执行导出
+            AnsiConsole.MarkupLine("[blue]▶ 执行首次协议导出...[/]");
+            var exportService = new ProtocolExportService();
+            var result = await exportService.ExportAsync(config, cancellationToken, silent: true);
+
+            if (!result.Success)
+            {
+                AnsiConsole.MarkupLine($"[red]✗ 首次导出失败:[/] {result.ErrorMessage}");
+                AnsiConsole.MarkupLine("[yellow]继续启动MCP服务器...[/]");
+            }
+            else
+            {
+                AnsiConsole.MarkupLine("[green]✓[/] 首次导出成功");
+            }
+
+            AnsiConsole.WriteLine();
+            AnsiConsole.MarkupLine("[blue]▶ 启动MCP服务器 (stdio模式)...[/]");
+            AnsiConsole.MarkupLine("[gray]  服务器正在运行，等待MCP客户端连接...[/]");
+            AnsiConsole.MarkupLine("[gray]  按 Ctrl+C 停止服务器[/]");
+            AnsiConsole.WriteLine();
+
+            // 启动MCP服务器（传入配置路径和DLL目录）
+            var server = new McpJsonRpcServer(exportService, configPath, dllDir);
+            await server.RunAsync(cancellationToken);
+
+            return 0;
+        });
+    }
+}
+
+/// <summary>
+/// JSON-RPC MCP服务器
+/// </summary>
+public class McpJsonRpcServer
+{
+    private readonly string _configPath;
+    private readonly string _dllBaseDir;
+    private readonly ProtocolExportService _exportService;
+    private readonly JsonSerializerOptions _jsonOptions;
+
+    public McpJsonRpcServer(ProtocolExportService exportService, string configPath, string dllBaseDir)
+    {
+        _exportService = exportService;
+        _configPath = configPath;
+        _dllBaseDir = dllBaseDir;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = false
+        };
+    }
+
+    public async Task RunAsync(CancellationToken ct)
+    {
+        // 发送初始化通知
+        await SendNotificationAsync("notifications/initialized", new JsonObject(), ct);
+
+        // 使用StreamReader读取stdin
+        using var reader = new StreamReader(Console.OpenStandardInput(), Encoding.UTF8);
+
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                // 读取一行JSON-RPC消息
+                var line = await reader.ReadLineAsync(ct);
+                if (line == null) break;
+                if (string.IsNullOrWhiteSpace(line)) continue;
+
+                try
+                {
+                    var message = JsonNode.Parse(line);
+                    if (message == null) continue;
+
+                    // 处理消息
+                    await ProcessMessageAsync(message, ct);
+                }
+                catch (JsonException ex)
+                {
+                    await SendErrorResponseAsync(null, -32700, $"Parse error: {ex.Message}", ct);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // 正常取消
+        }
+    }
+
+    private async Task ProcessMessageAsync(JsonNode message, CancellationToken ct)
+    {
+        var jsonRpc = message["jsonrpc"]?.GetValue<string>();
+        if (jsonRpc != "2.0")
+        {
+            await SendErrorResponseAsync(null, -32600, "Invalid JSON-RPC version", ct);
+            return;
+        }
+
+        var method = message["method"]?.GetValue<string>();
+        var id = message["id"];
+
+        // 处理请求
+        if (method != null)
+        {
+            switch (method)
+            {
+                case "initialize":
+                    await HandleInitializeAsync(id, ct);
+                    break;
+
+                case "tools/list":
+                    await HandleToolsListAsync(id, ct);
+                    break;
+
+                case "tools/call":
+                    await HandleToolsCallAsync(id, message["params"], ct);
+                    break;
+
+                default:
+                    if (id != null)
+                    {
+                        await SendErrorResponseAsync(id, -32601, $"Method not found: {method}", ct);
+                    }
+                    break;
+            }
+        }
+    }
+
+    private async Task HandleInitializeAsync(JsonNode? id, CancellationToken ct)
+    {
+        var result = new JsonObject
+        {
+            ["protocolVersion"] = "2024-11-05",
+            ["capabilities"] = new JsonObject
+            {
+                ["tools"] = new JsonObject { ["listChanged"] = true }
+            },
+            ["serverInfo"] = new JsonObject
+            {
+                ["name"] = "fantasy-protocol-to-code",
+                ["version"] = "2026.0.1002",
+                ["description"] = " Fantasy 框架的协议->代码类 导出工具，将 .proto 协议文件转换为 C# 消息类代码. 利用Fantasy框架开发 需要定义网络消息时请不要手写消息类!! 务必使用这个工具!! 以免出现消息类定义不完整的问题!!  "
+            }
+        };
+
+        await SendResponseAsync(id, result, ct);
+    }
+
+    private async Task HandleToolsListAsync(JsonNode? id, CancellationToken ct)
+    {
+        var result = new JsonObject
+        {
+            ["tools"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["name"] = "export_protocols",
+                    ["description"] = "导出Fantasy网络协议文件。根据.proto配置生成服务器和/或客户端的协议代码，返回实际导出的消息类存放路径等信息。",
+                    ["inputSchema"] = new JsonObject
+                    {
+                        ["type"] = "object",
+                        ["properties"] = new JsonObject
+                        {
+                            ["exportType"] = new JsonObject
+                            {
+                                ["type"] = "string",
+                                ["description"] = "导出哪些: 'Client'(仅导出客户端消息类), 'Server'(仅服务端消息类), 'All'(双端,默认), 一般来说导出双端即可.",
+                                ["enum"] = new JsonArray { "Client", "Server", "All" }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        await SendResponseAsync(id, result, ct);
+    }
+
+    private async Task HandleToolsCallAsync(JsonNode? id, JsonNode? @params, CancellationToken ct)
+    {
+        var toolName = @params?["name"]?.GetValue<string>();
+        var arguments = @params?["arguments"];
+
+        if (toolName == null)
+        {
+            await SendErrorResponseAsync(id, -32602, "Missing tool name", ct);
+            return;
+        }
+
+        // 重新加载配置以获取最新设置（使用DLL目录作为基准）
+        var freshConfig = await ProtocolExportService.LoadConfigFromFileAsync(_configPath, _dllBaseDir);
+        if (freshConfig == null)
+        {
+            await SendToolErrorAsync(id, $"无法加载配置文件: {_configPath}", ct);
+            return;
+        }
+
+        switch (toolName)
+        {
+            case "export_protocols":
+                await HandleExportProtocolsAsync(id, freshConfig, arguments, ct);
+                break;
+
+            default:
+                await SendErrorResponseAsync(id, -32601, $"Tool not found: {toolName}", ct);
+                break;
+        }
+    }
+
+    private async Task HandleExportProtocolsAsync(JsonNode? id, ProtocolExportConfig config, JsonNode? arguments, CancellationToken ct)
+    {
+        AnsiConsole.WriteLine();
+        AnsiConsole.MarkupLine("[blue]▶ 收到MCP导出请求[/]");
+
+        // 解析 exportType 参数，默认 All
+        var exportTypeStr = arguments?["exportType"]?.GetValue<string>() ?? "All";
+        if (!Enum.TryParse<ProtocolExportType>(exportTypeStr, out var exportType))
+        {
+            exportType = ProtocolExportType.All;
+        }
+
+        // 应用导出类型
+        config.ExportType = exportType;
+
+        var result = await _exportService.ExportAsync(config, ct, silent: true);
+
+        if (result.Success)
+        {
+            var exportTypeDisplay = exportType switch
+            {
+                ProtocolExportType.Client => "仅客户端",
+                ProtocolExportType.Server => "仅服务端",
+                ProtocolExportType.All => "双端",
+                _ => "双端"
+            };
+
+            var content = $"✓ 协议导出成功\n\n" +
+                         $"导出配置:\n" +
+                         $"  导出类型: {exportTypeDisplay}\n" +
+                         $"  协议目录: {config.ProtocolDir}\n" +
+                         $"  服务器目录: {(string.IsNullOrEmpty(config.ServerDir) ? "(未配置)" : config.ServerDir)}\n" +
+                         $"  客户端目录: {(string.IsNullOrEmpty(config.ClientDir) ? "(未配置)" : config.ClientDir)}";
+
+            await SendToolResultAsync(id, content, false, ct);
+        }
+        else
+        {
+            await SendToolErrorAsync(id, $"✗ 协议导出失败\n\n错误: {result.ErrorMessage}", ct);
+        }
+    }
+
+    private async Task SendResponseAsync(JsonNode? id, JsonObject result, CancellationToken ct)
+    {
+        var response = new JsonObject
+        {
+            ["jsonrpc"] = "2.0",
+            ["id"] = id?.DeepClone(),
+            ["result"] = result
+        };
+
+        await SendMessageAsync(response, ct);
+    }
+
+    private async Task SendErrorResponseAsync(JsonNode? id, int code, string message, CancellationToken ct)
+    {
+        var response = new JsonObject
+        {
+            ["jsonrpc"] = "2.0",
+            ["id"] = id?.DeepClone(),
+            ["error"] = new JsonObject
+            {
+                ["code"] = code,
+                ["message"] = message
+            }
+        };
+
+        await SendMessageAsync(response, ct);
+    }
+
+    private async Task SendNotificationAsync(string method, JsonObject @params, CancellationToken ct)
+    {
+        var notification = new JsonObject
+        {
+            ["jsonrpc"] = "2.0",
+            ["method"] = method,
+            ["params"] = @params
+        };
+
+        await SendMessageAsync(notification, ct);
+    }
+
+    private async Task SendToolResultAsync(JsonNode? id, string content, bool isError, CancellationToken ct)
+    {
+        var result = new JsonObject
+        {
+            ["content"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["type"] = "text",
+                    ["text"] = content
+                }
+            },
+            ["isError"] = isError
+        };
+
+        await SendResponseAsync(id, result, ct);
+    }
+
+    private async Task SendToolErrorAsync(JsonNode? id, string errorMessage, CancellationToken ct)
+    {
+        await SendToolResultAsync(id, errorMessage, true, ct);
+    }
+
+    private async Task SendMessageAsync(JsonObject message, CancellationToken ct)
+    {
+        var json = message.ToJsonString(_jsonOptions);
+        var bytes = Encoding.UTF8.GetBytes(json + "\n");
+
+        await Console.OpenStandardOutput().WriteAsync(bytes, ct);
+        await Console.Out.FlushAsync();
+    }
+}

--- a/Fantasy.Packages/Fantasy.ProtocolExportTool/Commands/ProtocolExportCommand.cs
+++ b/Fantasy.Packages/Fantasy.ProtocolExportTool/Commands/ProtocolExportCommand.cs
@@ -1,11 +1,10 @@
 using System;
 using System.CommandLine;
 using System.IO;
-using System.Text.Json;
 using System.Threading.Tasks;
-using Fantasy.ProtocolExportTool.Generators;
 using Fantasy.ProtocolExportTool.Interactive;
 using Fantasy.ProtocolExportTool.Models;
+using Fantasy.ProtocolExportTool.Services;
 using Spectre.Console;
 
 namespace Fantasy.ProtocolExportTool.Commands;
@@ -58,7 +57,7 @@ public class ProtocolExportCommand : Command
             if (isSilent)
             {
                 // 静默模式：从 ExporterSettings.json 加载配置
-                var loadedConfig = await LoadConfigFromFileAsync();
+                var loadedConfig = await ProtocolExportService.LoadConfigFromFileAsync("ExporterSettings.json", null);
                 if (loadedConfig == null)
                 {
                     return 1;
@@ -71,6 +70,7 @@ public class ProtocolExportCommand : Command
                 config = await new ProtocolExportWizard().RunAsync(protocolDir, serverDir, clientDir, exportType);
             }
 
+            // 验证目录
             if (!isSilent && !Directory.Exists(config.ProtocolDir))
             {
                 AnsiConsole.MarkupLine($"[red]错误:[/] 网络协议所在的位置的目录 '{config.ProtocolDir}' 不已存在。");
@@ -109,76 +109,11 @@ public class ProtocolExportCommand : Command
                 return 1;
             }
 
-            try
-            {
-                await new ProtocolGenerator().GenerateAsync(config);
-                return 0;
-            }
-            catch (Exception ex)
-            {
-                AnsiConsole.MarkupLine($"[red]错误:[/] {ex.Message}");
-                if (AnsiConsole.Confirm("显示堆栈跟踪？", false))
-                {
-                    AnsiConsole.WriteException(ex);
-                }
+            // 执行导出
+            var exportService = new ProtocolExportService();
+            var result = await exportService.ExportAsync(config, silent: isSilent);
 
-                return 1;
-            }
+            return result.Success ? 0 : 1;
         });
-    }
-
-    private static async Task<ProtocolExportConfig?> LoadConfigFromFileAsync()
-    {
-        const string settingsFileName = "ExporterSettings.json";
-
-        try
-        {
-            if (!File.Exists(settingsFileName))
-            {
-                AnsiConsole.MarkupLine($"[red]错误:[/] 找不到配置文件 '{settingsFileName}'。");
-                AnsiConsole.MarkupLine("[yellow]提示:[/] 请在当前目录下创建 ExporterSettings.json 文件。");
-                return null;
-            }
-
-            var jsonContent = await File.ReadAllTextAsync(settingsFileName);
-            var settings = JsonSerializer.Deserialize<ExporterSettings>(jsonContent, new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-                ReadCommentHandling = JsonCommentHandling.Skip,
-                AllowTrailingCommas = true
-            });
-
-            if (settings?.Export == null)
-            {
-                AnsiConsole.MarkupLine($"[red]错误:[/] 配置文件 '{settingsFileName}' 格式不正确。");
-                return null;
-            }
-
-            var config = new ProtocolExportConfig
-            {
-                ProtocolDir = settings.Export.NetworkProtocolDirectory.Value,
-                ServerDir = settings.Export.NetworkProtocolServerDirectory.Value,
-                ClientDir = settings.Export.NetworkProtocolClientDirectory.Value,
-                ExportType = ProtocolExportType.All
-            };
-
-            AnsiConsole.MarkupLine("[green]成功:[/] 已从 ExporterSettings.json 加载配置。");
-            // AnsiConsole.MarkupLine($"  协议目录: {config.ProtocolDir}");
-            // AnsiConsole.MarkupLine($"  服务器目录: {config.ServerDir}");
-            // AnsiConsole.MarkupLine($"  客户端目录: {config.ClientDir}");
-            // AnsiConsole.WriteLine();
-
-            return config;
-        }
-        catch (JsonException ex)
-        {
-            AnsiConsole.MarkupLine($"[red]错误:[/] 解析配置文件失败: {ex.Message}");
-            return null;
-        }
-        catch (Exception ex)
-        {
-            AnsiConsole.MarkupLine($"[red]错误:[/] 读取配置文件失败: {ex.Message}");
-            return null;
-        }
     }
 }

--- a/Fantasy.Packages/Fantasy.ProtocolExportTool/Fantasy.ProtocolExportTool.csproj
+++ b/Fantasy.Packages/Fantasy.ProtocolExportTool/Fantasy.ProtocolExportTool.csproj
@@ -12,7 +12,7 @@
     <ItemGroup>
       <PackageReference Include="Spectre.Console" Version="0.54.0" />
       <PackageReference Include="System.CommandLine" Version="2.0.0" />
-      <PackageReference Include="System.Text.Json" Version="9.0.0" />
+      <PackageReference Include="System.Text.Json" Version="9.0.3" />
     </ItemGroup>
 
     <ItemGroup>
@@ -39,6 +39,12 @@
       </None>
       <None Update="quick-build.sh">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <None Update="协议导出_MCP_使用说明.md">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
+      <None Update="publish.bat">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
     </ItemGroup>
 

--- a/Fantasy.Packages/Fantasy.ProtocolExportTool/Generators/Parsers/ProtocolFileParser.cs
+++ b/Fantasy.Packages/Fantasy.ProtocolExportTool/Generators/Parsers/ProtocolFileParser.cs
@@ -10,6 +10,8 @@ using Spectre.Console;
 
 namespace Fantasy.ProtocolExportTool.Generators.Parsers;
 
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+
 /// <summary>
 /// 解析结果
 /// </summary>

--- a/Fantasy.Packages/Fantasy.ProtocolExportTool/Program.cs
+++ b/Fantasy.Packages/Fantasy.ProtocolExportTool/Program.cs
@@ -1,9 +1,10 @@
 ﻿using System.CommandLine;
 using Fantasy.ProtocolExportTool.Commands;
 
-var rootCommand = new RootCommand("Fantasy 网络协议导出工具 2025.2.1422")
+var rootCommand = new RootCommand("Fantasy 网络协议导出工具 2026.0.1002")
 {
-    new ProtocolExportCommand()
+    new ProtocolExportCommand(),
+    new McpServerCommand()
 };
 
 return await rootCommand.Parse(args).InvokeAsync();

--- a/Fantasy.Packages/Fantasy.ProtocolExportTool/Services/ProtocolExportService.cs
+++ b/Fantasy.Packages/Fantasy.ProtocolExportTool/Services/ProtocolExportService.cs
@@ -1,0 +1,181 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Fantasy.ProtocolExportTool.Generators;
+using Fantasy.ProtocolExportTool.Models;
+using Spectre.Console;
+
+namespace Fantasy.ProtocolExportTool.Services;
+
+/// <summary>
+/// 协议导出服务 - 核心导出逻辑，可被命令行和MCP服务器共用
+/// </summary>
+public class ProtocolExportService
+{
+    /// <summary>
+    /// 执行协议导出
+    /// </summary>
+    /// <param name="config">导出配置</param>
+    /// <param name="ct">取消令牌</param>
+    /// <param name="silent">是否静默模式（不显示交互式UI）</param>
+    /// <returns>导出结果</returns>
+    public async Task<ExportResult> ExportAsync(ProtocolExportConfig config, CancellationToken ct = default, bool silent = false)
+    {
+        var result = new ExportResult { Success = false };
+
+        // 验证目录
+        if (!Directory.Exists(config.ProtocolDir))
+        {
+            result.ErrorMessage = $"协议目录不存在: {config.ProtocolDir}";
+            return result;
+        }
+
+        if (!string.IsNullOrEmpty(config.ServerDir) && !Directory.Exists(config.ServerDir))
+        {
+            try
+            {
+                Directory.CreateDirectory(config.ServerDir);
+            }
+            catch (Exception ex)
+            {
+                result.ErrorMessage = $"创建服务器目录失败: {ex.Message}";
+                return result;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(config.ClientDir) && !Directory.Exists(config.ClientDir))
+        {
+            try
+            {
+                Directory.CreateDirectory(config.ClientDir);
+            }
+            catch (Exception ex)
+            {
+                result.ErrorMessage = $"创建客户端目录失败: {ex.Message}";
+                return result;
+            }
+        }
+
+        if (string.IsNullOrEmpty(config.ServerDir) && string.IsNullOrEmpty(config.ClientDir))
+        {
+            result.ErrorMessage = "必须指定服务器目录或客户端目录至少一个";
+            return result;
+        }
+
+        try
+        {
+            if (silent)
+            {
+                // 静默模式：直接使用Console输出，避免与Progress冲突
+                Console.WriteLine("正在导出协议...");
+                await new ProtocolGenerator().GenerateAsync(config, ct);
+                Console.WriteLine("协议导出成功!");
+            }
+            else
+            {
+                // 交互模式：使用进度条
+                await new ProtocolGenerator().GenerateAsync(config, ct);
+                AnsiConsole.MarkupLine("[green]协议导出成功![/]");
+            }
+
+            result.Success = true;
+            result.Message = "协议导出成功";
+        }
+        catch (OperationCanceledException)
+        {
+            result.ErrorMessage = "导出已取消";
+            if (!silent)
+                AnsiConsole.MarkupLine("[yellow]导出已取消[/]");
+            else
+                Console.WriteLine("导出已取消");
+        }
+        catch (Exception ex)
+        {
+            result.ErrorMessage = ex.Message;
+            if (!silent)
+                AnsiConsole.MarkupLine($"[red]导出失败: {ex.Message}[/]");
+            else
+                Console.WriteLine($"导出失败: {ex.Message}");
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// 从配置文件加载导出配置
+    /// </summary>
+    /// <param name="settingsFileName">配置文件路径，默认为 ExporterSettings.json</param>
+    /// <param name="dllBaseDir">DLL所在目录，用于解析配置中的相对路径。为空时使用配置文件目录</param>
+    public static async Task<ProtocolExportConfig?> LoadConfigFromFileAsync(string settingsFileName = "ExporterSettings.json", string? dllBaseDir = null)
+    {
+        try
+        {
+            // 解析配置文件为绝对路径
+            var configFullPath = Path.GetFullPath(settingsFileName);
+            var configDir = Path.GetDirectoryName(configFullPath) ?? "";
+
+            if (!File.Exists(configFullPath))
+            {
+                AnsiConsole.MarkupLine($"[red]错误:[/] 找不到配置文件 '{configFullPath}'。");
+                return null;
+            }
+
+            var jsonContent = await File.ReadAllTextAsync(configFullPath);
+            var settings = JsonSerializer.Deserialize<ExporterSettings>(jsonContent, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+                ReadCommentHandling = JsonCommentHandling.Skip,
+                AllowTrailingCommas = true
+            });
+
+            if (settings?.Export == null)
+            {
+                AnsiConsole.MarkupLine($"[red]错误:[/] 配置文件 '{configFullPath}' 格式不正确。");
+                return null;
+            }
+
+            // 基准目录：使用配置文件所在目录
+            string baseDir = configDir;
+
+            // 解析各目录为绝对路径
+            string ResolveToAbsolute(string? path)
+            {
+                if (string.IsNullOrEmpty(path)) return "";
+                if (Path.IsPathRooted(path)) return path;
+                return Path.GetFullPath(Path.Combine(baseDir, path));
+            }
+
+            var config = new ProtocolExportConfig
+            {
+                ProtocolDir = ResolveToAbsolute(settings.Export.NetworkProtocolDirectory.Value),
+                ServerDir = ResolveToAbsolute(settings.Export.NetworkProtocolServerDirectory.Value),
+                ClientDir = ResolveToAbsolute(settings.Export.NetworkProtocolClientDirectory.Value),
+                ExportType = ProtocolExportType.All
+            };
+
+            return config;
+        }
+        catch (JsonException ex)
+        {
+            AnsiConsole.MarkupLine($"[red]错误:[/] 解析配置文件失败: {ex.Message}");
+            return null;
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.MarkupLine($"[red]错误:[/] 读取配置文件失败: {ex.Message}");
+            return null;
+        }
+    }
+}
+
+/// <summary>
+/// 导出结果
+/// </summary>
+public class ExportResult
+{
+    public bool Success { get; set; }
+    public string Message { get; set; } = string.Empty;
+    public string ErrorMessage { get; set; } = string.Empty;
+}

--- a/Fantasy.Packages/Fantasy.ProtocolExportTool/协议导出工具MCP_使用说明.md
+++ b/Fantasy.Packages/Fantasy.ProtocolExportTool/协议导出工具MCP_使用说明.md
@@ -1,0 +1,92 @@
+# Fantasy Protocol Export MCP 服务
+
+## 简介
+
+Fantasy Protocol Export Tool 支持作为 MCP (Model Context Protocol) 服务运行，允许 OpenCode（或其它支持 MCP 的编程客户端如 Cursor、Claude Code、Codex、Github Copilot 等）直接调用协议导出功能。
+
+## 启动方式
+
+确保配置好 MCP 客户端后（以 OpenCode 为例，Cursor、Claude Code、Codex 等类似），**请不要手动启动**：
+- 给模型发消息, 如"调用一次Fnatasy协议导出工具并返回", 
+- 模型应该会触发一次导出, 并返回导出消息。
+
+## MCP 客户端配置
+
+（以 OpenCode 为例，Cursor、Claude Code、Codex 等类似）
+
+在您使用的 MCP 客户端配置文件中添加（各客户端配置格式可能略有差异,如有特定客户端特殊字段请自行搜索）：
+
+```json
+{
+  "mcp": {
+    "fantasy-protocol-to-code": {
+      "type": "local",
+      "command": ["dotnet", "<dll路径>","mcp", "-c", "<协议配置路径>"],
+      "enabled": true
+    }
+  }
+}
+```
+**替换步骤**：
+- 将 `<dll路径>`替换为实际dll绝对路径，如 `F:MyPath/Fantasy.ProtocolExportTool/bin/Debug/net8.0/Fantasy.ProtocolExportTool.dll`;
+- 通过将 `<协议配置路径>` 替换为自定义路径, 指定 ExporterSettings.json 文件所在;
+- 以上两个步骤都不能省!! (否则模型无法正确启用 MCP)
+
+
+## 工具调用 (模型会自行识别, 如果没识别到, 检查上述的配置有没有做对)
+
+### export_protocols
+
+导出 Fantasy 网络协议文件为 C# 类。
+
+**参数：**
+- `exportType` (string, 可选): 导出类型，`"Client"`、`"Server"` 或 `"All"`(默认)
+
+**使用示例：**
+```json
+{
+  "tool": "export_protocols",
+  "arguments": {}
+}
+
+// 仅客户端
+{
+  "tool": "export_protocols",
+  "arguments": { "exportType": "Client" }
+}
+```
+
+**模型接收的返回消息：**
+```
+✓ 协议导出成功
+
+导出配置:
+  导出类型: 双端
+  协议目录: F:/.../NetworkProtocol
+  服务器目录: F:/.../NetworkProtocol
+  客户端目录: F:/.../NetworkProtocol
+```
+
+## 运行流程
+
+1. 启动时通过 `-c` 参数加载 `ExporterSettings.json` 配置文件
+2. 执行首次协议导出（失败会警告）
+3. 通过 stdio 与 MCP 客户端通信
+4. 等待并处理工具调用请求
+
+**注意**：MCP 服务必须保持运行，进程生命周期建议由Agent客户端管理。
+
+## 故障排除
+
+### MCP 连接失败
+
+1. 检查dll路径文件路径是否正确
+2. 检查配置文件完整路径
+3. 检查服务是否正在运行
+
+### 导出失败
+
+检查：
+1. 协议目录是否存在且包含 `.proto` 文件
+2. 服务器和客户端目录是否有写入权限
+3. 路径配置是否正确


### PR DESCRIPTION
- 新增McpServerCommand支持MCP协议调用
- JSON-RPC实现（避免现在.NET官方 MCP SDK不稳定问题）
- 添加.md中文使用说明文档
<img width="988" height="553" alt="image" src="https://github.com/user-attachments/assets/5c6b1a48-9839-4273-bee5-1aa493a3fb22" />

踩坑记录:
- MCP调用时Environment.ProcessPath不可靠，需从命令行参数解析DLL路径或配置路径
- 相对路径基于配置文件目录解析避免路径漂移
- 有的客户端比如OpenCode不支持workingDirectory需用command数组显式传参
- serverInfo需要version字段否则初始化失败