### PR TITLE
k8s部署的适配  以及 协议封禁 限流的钩子

### DIFF
--- a/Fantasy.Packages/Fantasy.Net/Fantasy.Net.csproj
+++ b/Fantasy.Packages/Fantasy.Net/Fantasy.Net.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <PackageId>Fantasy-Net</PackageId>
-        <PackageVersion>2026.0.1023</PackageVersion>
+        <PackageVersion>2026.0.1023-v2</PackageVersion>
         <Title>Fantasy-Net</Title>
         <Authors>qq362946</Authors>
         <owners>qq362946</owners>
@@ -91,3 +91,4 @@
     <Import Project="build\Fantasy-Net.props" />
     <Import Project="build\Fantasy-Net.targets" />
 </Project>
+

--- a/Fantasy.Packages/Fantasy.Net/Fantasy.xsd
+++ b/Fantasy.Packages/Fantasy.Net/Fantasy.xsd
@@ -119,6 +119,11 @@
         <xs:documentation>内网绑定IP地址</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="k8sInnerConnectIP" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>Kubernetes内网连接IP或域名，为空时使用innerBindIP</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:complexType>
 
   <!-- Processes types -->

--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Helper/NetworkHelper.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Helper/NetworkHelper.cs
@@ -66,18 +66,14 @@ namespace Fantasy.Helper
                     portSpan = span.Slice(lastColonIndex + 1);
                 }
                 
-                // 解析IP地址
-                if (!IPAddress.TryParse(ipSpan, out var ipAddress))
-                {
-                    throw new FormatException("Invalid IP address");
-                }
+                var host = ipSpan.ToString();
                 // 解析端口 
                 if (!int.TryParse(portSpan, out var port) || port < 0 || port > 65535)
                 {
                     throw new FormatException("Invalid port number");
                 }
                 
-                return new IPEndPoint(ipAddress, port);
+                return new IPEndPoint(ResolveHostAddress(host), port);
             }
             catch (Exception e)
             {
@@ -361,7 +357,36 @@ namespace Fantasy.Helper
         /// <returns><see cref="IPEndPoint"/> 实例。</returns>
         public static IPEndPoint ToIPEndPoint(string host, int port)
         {
-            return new IPEndPoint(IPAddress.Parse(host), port);
+            return new IPEndPoint(ResolveHostAddress(host), port);
+        }
+
+        /// <summary>
+        /// 将IP或DNS主机名解析为IPAddress。
+        /// </summary>
+        /// <param name="host"></param>
+        /// <returns></returns>
+        private static IPAddress ResolveHostAddress(string host)
+        {
+            if (IPAddress.TryParse(host, out var ipAddress))
+            {
+                return ipAddress;
+            }
+
+            var addresses = Dns.GetHostAddresses(host);
+            if (addresses.Length == 0)
+            {
+                throw new FormatException($"Host '{host}' could not be resolved");
+            }
+
+            foreach (var address in addresses)
+            {
+                if (address.AddressFamily == AddressFamily.InterNetwork)
+                {
+                    return address;
+                }
+            }
+
+            return addresses[0];
         }
 
         /// <summary>

--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Helper/NetworkHelper.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Helper/NetworkHelper.cs
@@ -77,10 +77,10 @@ namespace Fantasy.Helper
             }
             catch (Exception e)
             {
-                Log.Error($"Error parsing IP and Port: '{address}'. " +
-                          $"Expected format: 'IP:Port' (e.g., '192.168.1.1:8080' or '[::1]:8080'). " +
+                Log.Error($"Error resolving endpoint: '{address}'. " +
+                          $"Expected format: 'Host:Port' (e.g., '192.168.1.1:8080', 'server.namespace.svc.cluster.local:8080' or '[::1]:8080'). " +
                           $"Error: {e.Message}");
-                return null;
+                throw;
             }
         }
 

--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Network/Message/IOuterMessageGuard.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Network/Message/IOuterMessageGuard.cs
@@ -1,0 +1,12 @@
+using System;
+using Fantasy.Network;
+
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace Fantasy.Network.Interface
+{
+    public interface IOuterMessageGuard
+    {
+        bool TryReject(Session session, uint protocolCode, uint rpcId, uint opCodeType, Type messageType, out uint errorCode);
+    }
+}

--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Network/Message/Scheduler/OuterMessageScheduler.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Network/Message/Scheduler/OuterMessageScheduler.cs
@@ -77,6 +77,11 @@ namespace Fantasy.Scheduler
                             throw new Exception($"可能遭受到恶意发包或没有协议定义ProtocolCode ProtocolCode：{packInfo.ProtocolCode}");
                         }
                         
+                        if (TryRejectByOuterMessageGuard(session, packInfo, messageType))
+                        {
+                            return;
+                        }
+
                         var message = packInfo.Deserialize(messageType);
                         MessageDispatcherComponent.MessageHandler(session, messageType, message, packInfo.RpcId, packInfo.ProtocolCode);
                     }
@@ -120,6 +125,11 @@ namespace Fantasy.Scheduler
                             throw new Exception($"OuterMessageScheduler error 可能遭受到恶意发包或没有协议定义ProtocolCode ProtocolCode：{packInfo.ProtocolCode}");
                         }
 
+                        if (TryRejectByOuterMessageGuard(session, packInfo, messageType))
+                        {
+                            return;
+                        }
+
                         var addressableRouteComponent = session.AddressableRouteComponent;
 
                         if (addressableRouteComponent == null)
@@ -150,6 +160,11 @@ namespace Fantasy.Scheduler
                         if (messageType == null)
                         {
                             throw new Exception($"OuterMessageScheduler error 可能遭受到恶意发包或没有协议定义ProtocolCode ProtocolCode：{packInfo.ProtocolCode}");
+                        }
+
+                        if (TryRejectByOuterMessageGuard(session, packInfo, messageType))
+                        {
+                            return;
                         }
 
                         var addressableRouteComponent = session.AddressableRouteComponent;
@@ -200,6 +215,11 @@ namespace Fantasy.Scheduler
                             throw new Exception($"OuterMessageScheduler error 可能遭受到恶意发包或没有协议定义ProtocolCode ProtocolCode：{packInfo.ProtocolCode}");
                         }
                     
+                        if (TryRejectByOuterMessageGuard(session, packInfo, messageType))
+                        {
+                            return;
+                        }
+
                         var routeComponent = session.RouteComponent;
 
                         if (routeComponent == null)
@@ -245,6 +265,11 @@ namespace Fantasy.Scheduler
                             throw new Exception($"OuterMessageScheduler error 可能遭受到恶意发包或没有协议定义ProtocolCode ProtocolCode：{packInfo.ProtocolCode}");
                         }
                     
+                        if (TryRejectByOuterMessageGuard(session, packInfo, messageType))
+                        {
+                            return;
+                        }
+
                         var routeComponent = session.RouteComponent;
 
                         if (routeComponent == null)
@@ -298,6 +323,11 @@ namespace Fantasy.Scheduler
                             throw new Exception($"OuterMessageScheduler error 可能遭受到恶意发包或没有协议定义ProtocolCode ProtocolCode：{packInfo.ProtocolCode}");
                         }
                     
+                        if (TryRejectByOuterMessageGuard(session, packInfo, messageType))
+                        {
+                            return;
+                        }
+
                         var sessionRoamingComponent = session.SessionRoamingComponent;
 
                         if (sessionRoamingComponent == null)
@@ -338,6 +368,11 @@ namespace Fantasy.Scheduler
                             throw new Exception($"OuterMessageScheduler error 可能遭受到恶意发包或没有协议定义ProtocolCode ProtocolCode：{packInfo.ProtocolCode}");
                         }
                     
+                        if (TryRejectByOuterMessageGuard(session, packInfo, messageType))
+                        {
+                            return;
+                        }
+
                         var sessionRoamingComponent = session.SessionRoamingComponent;
 
                         if (sessionRoamingComponent == null)
@@ -372,6 +407,31 @@ namespace Fantasy.Scheduler
                     throw new NotSupportedException($"OuterMessageScheduler Received unsupported message protocolCode:{packInfo.ProtocolCode}\n1、请检查该协议所在的程序集是否在框架初始化的时候添加到框架中。\n2、如果看到这个消息表示你有可能用的老版本的导出工具，请更换为最新的导出工具。\n IP地址:{ipAddress}");
                 }
             }
+        }
+
+        private bool TryRejectByOuterMessageGuard(Session session, APackInfo packInfo, Type messageType)
+        {
+            var outerMessageGuard = Scene.OuterMessageGuard;
+            if (outerMessageGuard == null || !outerMessageGuard.TryReject(session, packInfo.ProtocolCode, packInfo.RpcId, packInfo.OpCodeIdStruct.Protocol, messageType, out var errorCode))
+            {
+                return false;
+            }
+
+            switch (packInfo.OpCodeIdStruct.Protocol)
+            {
+                case OpCodeType.OuterRequest:
+                case OpCodeType.OuterAddressableRequest:
+                case OpCodeType.OuterCustomRouteRequest:
+                case OpCodeType.OuterRoamingRequest:
+                {
+                    var response = MessageDispatcherComponent.CreateResponse(packInfo.ProtocolCode, errorCode);
+                    var responseType = MessageDispatcherComponent.GetOpCodeType(response.OpCode()) ?? response.GetType();
+                    session.Send(response, responseType, packInfo.RpcId);
+                    break;
+                }
+            }
+
+            return true;
         }
     }
 #endif

--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Network/Protocol/KCP/Client/KCPClientNetwork.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Network/Protocol/KCP/Client/KCPClientNetwork.cs
@@ -148,10 +148,21 @@ namespace Fantasy.Network.KCP
             IsInit = true;
             _startTime = TimeHelper.Now;
             ChannelId = CreateChannelId();
-            _remoteAddress = NetworkHelper.GetIPEndPoint(remoteAddress);
             OnConnectFail = onConnectFail;
             OnConnectComplete = onConnectComplete;
             OnConnectDisconnect = onConnectDisconnect;
+            try
+            {
+                _remoteAddress = NetworkHelper.GetIPEndPoint(remoteAddress);
+            }
+            catch
+            {
+                _connectDisconnectEvent = false;
+                OnConnectFail?.Invoke();
+                Dispose();
+                throw;
+            }
+
             _connectEventArgs.Completed += OnConnectSocketCompleted;
             _connectTimeoutId = Scene.TimerComponent.Net.OnceTimer(connectTimeout, () =>
             {

--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Network/Protocol/TCP/Client/TCPClientNetwork.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Network/Protocol/TCP/Client/TCPClientNetwork.cs
@@ -136,7 +136,18 @@ namespace Fantasy.Network.TCP
                 Dispose();
             });
             _packetParser = PacketParserFactory.CreateReadOnlyMemoryPacketParser(this);
-            _remoteEndPoint = NetworkHelper.GetIPEndPoint(remoteAddress);
+            try
+            {
+                _remoteEndPoint = NetworkHelper.GetIPEndPoint(remoteAddress);
+            }
+            catch
+            {
+                _connectDisconnectEvent = false;
+                _onConnectFail?.Invoke();
+                Dispose();
+                throw;
+            }
+
             _socket = new Socket(_remoteEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
             _socket.NoDelay = true;
             _socket.SetSocketBufferToOsLimit();

--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Platform/Net/ConfigLoader.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Platform/Net/ConfigLoader.cs
@@ -137,7 +137,8 @@ public static class ConfigLoader
                 Id = uint.Parse(GetRequiredAttribute(machineNode, "id")),
                 OuterIP = GetRequiredAttribute(machineNode, "outerIP"),
                 OuterBindIP = GetRequiredAttribute(machineNode, "outerBindIP"),
-                InnerBindIP = GetRequiredAttribute(machineNode, "innerBindIP")
+                InnerBindIP = GetRequiredAttribute(machineNode, "innerBindIP"),
+                K8sInnerConnectIP = GetOptionalAttribute(machineNode, "k8sInnerConnectIP") ?? string.Empty
             };
             machineList.Add(machine);
         }

--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Platform/Net/ConfigTable/MachineConfig.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Platform/Net/ConfigTable/MachineConfig.cs
@@ -108,6 +108,18 @@ namespace Fantasy.Platform.Net
         /// 内网绑定IP
         /// </summary>
         public string InnerBindIP { get; set; }  
+        /// <summary>
+        /// Kubernetes内网连接IP或域名，为空时使用InnerBindIP。
+        /// </summary>
+        public string K8sInnerConnectIP { get; set; } = string.Empty;
+        /// <summary>
+        /// 获取远程进程连接该机器时使用的内网地址。
+        /// </summary>
+        /// <returns></returns>
+        public string GetInnerConnectIP()
+        {
+            return string.IsNullOrWhiteSpace(K8sInnerConnectIP) ? InnerBindIP : K8sInnerConnectIP;
+        }
     }
 }
 #endif

--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Scene/Scene.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Scene/Scene.cs
@@ -739,7 +739,7 @@ namespace Fantasy
                 throw new Exception($"The machine with machineId {processConfig.MachineId} was not found in the configuration file");
             }
             
-            var remoteAddress = $"{machineConfig.InnerBindIP}:{sceneConfig.InnerPort}";
+            var remoteAddress = $"{machineConfig.GetInnerConnectIP()}:{sceneConfig.InnerPort}";
             var client = NetworkProtocolFactory.CreateClient(Scene, ProgramDefine.InnerNetwork, NetworkTarget.Inner, false);
             var session = client.Connect(remoteAddress, null, () =>
             {

--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Scene/Scene.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Scene/Scene.cs
@@ -196,6 +196,10 @@ namespace Fantasy
         /// Scene下的领域事件组件
         /// </summary>
         public SphereEventComponent SphereEventComponent  { get; internal set; }
+        /// <summary>
+        /// 外网消息进入业务派发或路由转发前的可选拦截器。
+        /// </summary>
+        public IOuterMessageGuard? OuterMessageGuard { get; set; }
 #endif
         #endregion
 

--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Scene/Scene.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Scene/Scene.cs
@@ -16,6 +16,7 @@ using Fantasy.Timer;
 using Fantasy.Database;
 using Fantasy.Platform.Net;
 using System.Collections.Frozen;
+using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using Fantasy.Network.Route;
 using Fantasy.Network.Roaming;
@@ -749,6 +750,12 @@ namespace Fantasy
             {
                 Log.Error($"Unable to connect to the target server sourceServerId:{Scene.Process.Id} targetServerId:{sceneConfig.ProcessConfigId}");
             }, null, false);
+            if (session == null || session.IsDisposed)
+            {
+                client.Dispose();
+                throw new SocketException((int)SocketError.NotConnected);
+            }
+
             _processSessionInfos.Add(sceneId, new ProcessSessionInfo(session, client));
             return session;
         }

--- a/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Helper/NetworkHelper.cs
+++ b/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Helper/NetworkHelper.cs
@@ -66,18 +66,14 @@ namespace Fantasy.Helper
                     portSpan = span.Slice(lastColonIndex + 1);
                 }
                 
-                // 解析IP地址
-                if (!IPAddress.TryParse(ipSpan, out var ipAddress))
-                {
-                    throw new FormatException("Invalid IP address");
-                }
+                var host = ipSpan.ToString();
                 // 解析端口 
                 if (!int.TryParse(portSpan, out var port) || port < 0 || port > 65535)
                 {
                     throw new FormatException("Invalid port number");
                 }
                 
-                return new IPEndPoint(ipAddress, port);
+                return new IPEndPoint(ResolveHostAddress(host), port);
             }
             catch (Exception e)
             {
@@ -361,7 +357,36 @@ namespace Fantasy.Helper
         /// <returns><see cref="IPEndPoint"/> 实例。</returns>
         public static IPEndPoint ToIPEndPoint(string host, int port)
         {
-            return new IPEndPoint(IPAddress.Parse(host), port);
+            return new IPEndPoint(ResolveHostAddress(host), port);
+        }
+
+        /// <summary>
+        /// 将IP或DNS主机名解析为IPAddress。
+        /// </summary>
+        /// <param name="host"></param>
+        /// <returns></returns>
+        private static IPAddress ResolveHostAddress(string host)
+        {
+            if (IPAddress.TryParse(host, out var ipAddress))
+            {
+                return ipAddress;
+            }
+
+            var addresses = Dns.GetHostAddresses(host);
+            if (addresses.Length == 0)
+            {
+                throw new FormatException($"Host '{host}' could not be resolved");
+            }
+
+            foreach (var address in addresses)
+            {
+                if (address.AddressFamily == AddressFamily.InterNetwork)
+                {
+                    return address;
+                }
+            }
+
+            return addresses[0];
         }
 
         /// <summary>

--- a/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Platform/Net/ConfigLoader.cs
+++ b/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Platform/Net/ConfigLoader.cs
@@ -137,7 +137,8 @@ public static class ConfigLoader
                 Id = uint.Parse(GetRequiredAttribute(machineNode, "id")),
                 OuterIP = GetRequiredAttribute(machineNode, "outerIP"),
                 OuterBindIP = GetRequiredAttribute(machineNode, "outerBindIP"),
-                InnerBindIP = GetRequiredAttribute(machineNode, "innerBindIP")
+                InnerBindIP = GetRequiredAttribute(machineNode, "innerBindIP"),
+                K8sInnerConnectIP = GetOptionalAttribute(machineNode, "k8sInnerConnectIP") ?? string.Empty
             };
             machineList.Add(machine);
         }

--- a/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Platform/Net/ConfigTable/MachineConfig.cs
+++ b/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Platform/Net/ConfigTable/MachineConfig.cs
@@ -108,6 +108,18 @@ namespace Fantasy.Platform.Net
         /// 内网绑定IP
         /// </summary>
         public string InnerBindIP { get; set; }  
+        /// <summary>
+        /// Kubernetes内网连接IP或域名，为空时使用InnerBindIP。
+        /// </summary>
+        public string K8sInnerConnectIP { get; set; } = string.Empty;
+        /// <summary>
+        /// 获取远程进程连接该机器时使用的内网地址。
+        /// </summary>
+        /// <returns></returns>
+        public string GetInnerConnectIP()
+        {
+            return string.IsNullOrWhiteSpace(K8sInnerConnectIP) ? InnerBindIP : K8sInnerConnectIP;
+        }
     }
 }
 #endif

--- a/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Scene/Scene.cs
+++ b/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Scene/Scene.cs
@@ -739,7 +739,7 @@ namespace Fantasy
                 throw new Exception($"The machine with machineId {processConfig.MachineId} was not found in the configuration file");
             }
             
-            var remoteAddress = $"{machineConfig.InnerBindIP}:{sceneConfig.InnerPort}";
+            var remoteAddress = $"{machineConfig.GetInnerConnectIP()}:{sceneConfig.InnerPort}";
             var client = NetworkProtocolFactory.CreateClient(Scene, ProgramDefine.InnerNetwork, NetworkTarget.Inner, false);
             var session = client.Connect(remoteAddress, null, () =>
             {

--- a/examples/Server/APP/Entity/Fantasy.xsd
+++ b/examples/Server/APP/Entity/Fantasy.xsd
@@ -119,6 +119,11 @@
         <xs:documentation>内网绑定IP地址</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="k8sInnerConnectIP" type="xs:string" use="optional">
+      <xs:annotation>
+        <xs:documentation>Kubernetes内网连接IP或域名，为空时使用innerBindIP</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:complexType>
 
   <!-- Processes types -->


### PR DESCRIPTION
适配了一下 k8s 部署的 地址解析，但是会需要启动瞬间的 服务不存在的报错 这里 不能直接 设置为 null 而是改为抛出异常
上层尝试 重试  
感觉不是个好的建议，只是目前可以解决问题

其次 对封禁 限流的钩子  gate 目前 如果想要 限制 协议的频率 或者 线上关闭某些协议的时候 缺少底层支持
这里以最小化修改方式 补了一个 IOuterMessageGuard 接口 在业务层实现逻辑