### PR TITLE
修复重连后旧 Session 延迟删除新 Roaming 组件

### DIFF
--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Network/Roaming/Component/RoamingComponent.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Network/Roaming/Component/RoamingComponent.cs
@@ -189,6 +189,10 @@ public sealed class RoamingComponent : Entity
         }
         else
         {
+            // 新Session开始绑定相同roamingId时，立即取消已经登记的旧Session延迟删除任务。
+            // 后面的owner校验还会兜底处理旧DisposeAsync在本次绑定之后才恢复并创建任务的竞态。
+            CancelRemoveTask(roamingId);
+
             if (!_sessionRoamingComponents.TryGetValue(roamingId, out sessionRoamingComponent))
             {
                 sessionRoamingComponent = Entity.Create<SessionRoamingComponent>(Scene, roamingId, true, true);
@@ -212,12 +216,9 @@ public sealed class RoamingComponent : Entity
                     }
                     parentSession.SessionRoamingComponent = null;
                 }
-                else
-                {
-                    // 有可能关联的Session已经断开过，需要清除下定时删除任务
-                    session.Scene.RoamingComponent.CancelRemoveTask(roamingId);
-                }
 
+                // 必须在下面的await之前切换owner，使旧Session正在运行的DisposeAsync无法再删除当前绑定。
+                sessionRoamingComponent.OwnerSessionRuntimeId = session.RuntimeId;
                 sessionRoamingComponent.Session = session;
                 session.SessionRoamingComponent = sessionRoamingComponent;
                 // 重新设定ForwardSessionAddress
@@ -225,7 +226,9 @@ public sealed class RoamingComponent : Entity
                 status = CreateRoamingStatus.AlreadyExists;
             }
             
-            session.AddComponent<SessionRoamingFlgComponent>(roamingId).DelayRemove = delayRemove;
+            var newSessionRoamingFlgComponent = session.AddComponent<SessionRoamingFlgComponent>(roamingId);
+            newSessionRoamingFlgComponent.DelayRemove = delayRemove;
+            newSessionRoamingFlgComponent.OwnerSessionRuntimeId = session.RuntimeId;
         }
 
         return new CreateRoamingResult(status, sessionRoamingComponent!);
@@ -316,30 +319,47 @@ public sealed class RoamingComponent : Entity
     /// <param name="roamingId"></param>
     /// <param name="roamingType">要移除的RoamingType，默认不设置是移除所有漫游。</param>
     /// <param name="delayRemove">当设置了延迟移除时间后，会在设置的时间后再进行移除。</param>
-    internal async FTask Remove(long roamingId, int roamingType, int delayRemove = 0)
+    /// <param name="expectedOwnerSessionRuntimeId">非0时，仅允许删除仍属于该Session的漫游组件。</param>
+    internal async FTask Remove(
+        long roamingId,
+        int roamingType,
+        int delayRemove = 0,
+        long expectedOwnerSessionRuntimeId = 0)
     {
         if (_isInnerDisposed)
         {
             return;
         }
-        
+
+        // 旧Session的DisposeAsync可能在新Session完成重连后才从StopForwarding恢复。
+        // 必须先校验owner再取消任务，避免旧清理流程取消或覆盖新Session的清理状态。
+        if (expectedOwnerSessionRuntimeId != 0 &&
+            (!_sessionRoamingComponents.TryGetValue(roamingId, out var current) ||
+             current.OwnerSessionRuntimeId != expectedOwnerSessionRuntimeId))
+        {
+            return;
+        }
+
         CancelRemoveTask(roamingId);
 
         if (delayRemove <= 0)
         {
-            await InnerRemove(roamingId, roamingType);
+            await InnerRemove(roamingId, roamingType, expectedOwnerSessionRuntimeId);
             return;
         }
 
         var taskId = _timerSchedulerNet.OnceTimer(delayRemove, () =>
         {
-            InnerRemove(roamingId, roamingType).Coroutine();
+            InnerRemove(roamingId, roamingType, expectedOwnerSessionRuntimeId).Coroutine();
         });
         
         _delayRemoveTaskId.Add(roamingId, taskId);
     }
 
-    private async FTask InnerRemove(long roamingId, int roamingType)
+    private async FTask InnerRemove(
+        long roamingId,
+        int roamingType,
+        long expectedOwnerSessionRuntimeId = 0)
     {
         if (_isInnerDisposed)
         {
@@ -348,6 +368,15 @@ public sealed class RoamingComponent : Entity
 
         if (!_sessionRoamingComponents.TryGetValue(roamingId, out var sessionRoamingComponent))
         {
+            return;
+        }
+
+        // 定时器触发前可能已经发生重连。只按roamingId查找会命中新Session的组件，
+        // 因此必须再次校验绑定Session，防止180秒旧任务误删当前有效连接。
+        if (expectedOwnerSessionRuntimeId != 0 &&
+            sessionRoamingComponent.OwnerSessionRuntimeId != expectedOwnerSessionRuntimeId)
+        {
+            _delayRemoveTaskId.Remove(roamingId);
             return;
         }
 

--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Network/Roaming/Component/SessionRoamingComponent.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Network/Roaming/Component/SessionRoamingComponent.cs
@@ -34,6 +34,12 @@ internal static class RoamingConstants
 public sealed class SessionRoamingComponent : Entity
 {
     internal EntityReference<Session> Session;
+
+    /// <summary>
+    /// 当前绑定的外网Session RuntimeId。
+    /// 延迟删除必须校验该值，避免旧Session遗留的定时任务误删重连后新Session正在使用的漫游组件。
+    /// </summary>
+    internal long OwnerSessionRuntimeId;
     
     private CoroutineLock? _roamingLock;
     private CoroutineLock? _roamingMessageLock;
@@ -56,6 +62,7 @@ public sealed class SessionRoamingComponent : Entity
         _roamingMessageLock = scene.CoroutineLockComponent.Create(this.GetType().TypeHandle.Value.ToInt64());
         
         Session = session;
+        OwnerSessionRuntimeId = session.RuntimeId;
         session.SessionRoamingComponent = this;
     }
 
@@ -82,6 +89,7 @@ public sealed class SessionRoamingComponent : Entity
         }
         
         Session.Clear();
+        OwnerSessionRuntimeId = 0;
         _timerComponent = null;
         _networkMessagingComponent = null;
         _messageDispatcherComponent = null;

--- a/Fantasy.Packages/Fantasy.Net/Runtime/Core/Network/Roaming/Component/SessionRoamingFlgComponent.cs
+++ b/Fantasy.Packages/Fantasy.Net/Runtime/Core/Network/Roaming/Component/SessionRoamingFlgComponent.cs
@@ -9,6 +9,12 @@ internal sealed class SessionRoamingFlgComponent : Entity
     private bool _isInnerDisposed;
     public bool DoNotRemove;
     public int DelayRemove;
+
+    /// <summary>
+    /// 创建当前标记组件时绑定的外网Session RuntimeId。
+    /// 用于确保本组件发起的延迟删除只能清理同一代Session的漫游绑定。
+    /// </summary>
+    public long OwnerSessionRuntimeId;
     
     public override void Dispose()
     {
@@ -24,6 +30,7 @@ internal sealed class SessionRoamingFlgComponent : Entity
     private async FTask DisposeAsync()
     {
         var roamingId = Id;
+        var ownerSessionRuntimeId = OwnerSessionRuntimeId;
 
         if (!DoNotRemove && DelayRemove > 0)
         {
@@ -32,11 +39,16 @@ internal sealed class SessionRoamingFlgComponent : Entity
             if (sceneRoamingComponent.TryGet(roamingId, out var roamingComponent))
             {
                 await roamingComponent.StopForwarding();
-                await sceneRoamingComponent.Remove(roamingId, 0, DelayRemove);
+                await sceneRoamingComponent.Remove(
+                    roamingId,
+                    0,
+                    DelayRemove,
+                    ownerSessionRuntimeId);
             }
         }
 
         DelayRemove = 0;
+        OwnerSessionRuntimeId = 0;
         DoNotRemove = false;
         _isInnerDisposed = false;
         

--- a/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Network/Roaming/Component/RoamingComponent.cs
+++ b/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Network/Roaming/Component/RoamingComponent.cs
@@ -189,6 +189,10 @@ public sealed class RoamingComponent : Entity
         }
         else
         {
+            // 新Session开始绑定相同roamingId时，立即取消已经登记的旧Session延迟删除任务。
+            // 后面的owner校验还会兜底处理旧DisposeAsync在本次绑定之后才恢复并创建任务的竞态。
+            CancelRemoveTask(roamingId);
+
             if (!_sessionRoamingComponents.TryGetValue(roamingId, out sessionRoamingComponent))
             {
                 sessionRoamingComponent = Entity.Create<SessionRoamingComponent>(Scene, roamingId, true, true);
@@ -212,12 +216,9 @@ public sealed class RoamingComponent : Entity
                     }
                     parentSession.SessionRoamingComponent = null;
                 }
-                else
-                {
-                    // 有可能关联的Session已经断开过，需要清除下定时删除任务
-                    session.Scene.RoamingComponent.CancelRemoveTask(roamingId);
-                }
 
+                // 必须在下面的await之前切换owner，使旧Session正在运行的DisposeAsync无法再删除当前绑定。
+                sessionRoamingComponent.OwnerSessionRuntimeId = session.RuntimeId;
                 sessionRoamingComponent.Session = session;
                 session.SessionRoamingComponent = sessionRoamingComponent;
                 // 重新设定ForwardSessionAddress
@@ -225,7 +226,9 @@ public sealed class RoamingComponent : Entity
                 status = CreateRoamingStatus.AlreadyExists;
             }
             
-            session.AddComponent<SessionRoamingFlgComponent>(roamingId).DelayRemove = delayRemove;
+            var newSessionRoamingFlgComponent = session.AddComponent<SessionRoamingFlgComponent>(roamingId);
+            newSessionRoamingFlgComponent.DelayRemove = delayRemove;
+            newSessionRoamingFlgComponent.OwnerSessionRuntimeId = session.RuntimeId;
         }
 
         return new CreateRoamingResult(status, sessionRoamingComponent!);
@@ -316,30 +319,47 @@ public sealed class RoamingComponent : Entity
     /// <param name="roamingId"></param>
     /// <param name="roamingType">要移除的RoamingType，默认不设置是移除所有漫游。</param>
     /// <param name="delayRemove">当设置了延迟移除时间后，会在设置的时间后再进行移除。</param>
-    internal async FTask Remove(long roamingId, int roamingType, int delayRemove = 0)
+    /// <param name="expectedOwnerSessionRuntimeId">非0时，仅允许删除仍属于该Session的漫游组件。</param>
+    internal async FTask Remove(
+        long roamingId,
+        int roamingType,
+        int delayRemove = 0,
+        long expectedOwnerSessionRuntimeId = 0)
     {
         if (_isInnerDisposed)
         {
             return;
         }
-        
+
+        // 旧Session的DisposeAsync可能在新Session完成重连后才从StopForwarding恢复。
+        // 必须先校验owner再取消任务，避免旧清理流程取消或覆盖新Session的清理状态。
+        if (expectedOwnerSessionRuntimeId != 0 &&
+            (!_sessionRoamingComponents.TryGetValue(roamingId, out var current) ||
+             current.OwnerSessionRuntimeId != expectedOwnerSessionRuntimeId))
+        {
+            return;
+        }
+
         CancelRemoveTask(roamingId);
 
         if (delayRemove <= 0)
         {
-            await InnerRemove(roamingId, roamingType);
+            await InnerRemove(roamingId, roamingType, expectedOwnerSessionRuntimeId);
             return;
         }
 
         var taskId = _timerSchedulerNet.OnceTimer(delayRemove, () =>
         {
-            InnerRemove(roamingId, roamingType).Coroutine();
+            InnerRemove(roamingId, roamingType, expectedOwnerSessionRuntimeId).Coroutine();
         });
         
         _delayRemoveTaskId.Add(roamingId, taskId);
     }
 
-    private async FTask InnerRemove(long roamingId, int roamingType)
+    private async FTask InnerRemove(
+        long roamingId,
+        int roamingType,
+        long expectedOwnerSessionRuntimeId = 0)
     {
         if (_isInnerDisposed)
         {
@@ -348,6 +368,15 @@ public sealed class RoamingComponent : Entity
 
         if (!_sessionRoamingComponents.TryGetValue(roamingId, out var sessionRoamingComponent))
         {
+            return;
+        }
+
+        // 定时器触发前可能已经发生重连。只按roamingId查找会命中新Session的组件，
+        // 因此必须再次校验绑定Session，防止180秒旧任务误删当前有效连接。
+        if (expectedOwnerSessionRuntimeId != 0 &&
+            sessionRoamingComponent.OwnerSessionRuntimeId != expectedOwnerSessionRuntimeId)
+        {
+            _delayRemoveTaskId.Remove(roamingId);
             return;
         }
 

--- a/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Network/Roaming/Component/SessionRoamingComponent.cs
+++ b/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Network/Roaming/Component/SessionRoamingComponent.cs
@@ -34,6 +34,12 @@ internal static class RoamingConstants
 public sealed class SessionRoamingComponent : Entity
 {
     internal EntityReference<Session> Session;
+
+    /// <summary>
+    /// 当前绑定的外网Session RuntimeId。
+    /// 延迟删除必须校验该值，避免旧Session遗留的定时任务误删重连后新Session正在使用的漫游组件。
+    /// </summary>
+    internal long OwnerSessionRuntimeId;
     
     private CoroutineLock? _roamingLock;
     private CoroutineLock? _roamingMessageLock;
@@ -56,6 +62,7 @@ public sealed class SessionRoamingComponent : Entity
         _roamingMessageLock = scene.CoroutineLockComponent.Create(this.GetType().TypeHandle.Value.ToInt64());
         
         Session = session;
+        OwnerSessionRuntimeId = session.RuntimeId;
         session.SessionRoamingComponent = this;
     }
 
@@ -82,6 +89,7 @@ public sealed class SessionRoamingComponent : Entity
         }
         
         Session.Clear();
+        OwnerSessionRuntimeId = 0;
         _timerComponent = null;
         _networkMessagingComponent = null;
         _messageDispatcherComponent = null;

--- a/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Network/Roaming/Component/SessionRoamingFlgComponent.cs
+++ b/Fantasy.Packages/Fantasy.Unity/Runtime/Core/Network/Roaming/Component/SessionRoamingFlgComponent.cs
@@ -9,6 +9,12 @@ internal sealed class SessionRoamingFlgComponent : Entity
     private bool _isInnerDisposed;
     public bool DoNotRemove;
     public int DelayRemove;
+
+    /// <summary>
+    /// 创建当前标记组件时绑定的外网Session RuntimeId。
+    /// 用于确保本组件发起的延迟删除只能清理同一代Session的漫游绑定。
+    /// </summary>
+    public long OwnerSessionRuntimeId;
     
     public override void Dispose()
     {
@@ -24,6 +30,7 @@ internal sealed class SessionRoamingFlgComponent : Entity
     private async FTask DisposeAsync()
     {
         var roamingId = Id;
+        var ownerSessionRuntimeId = OwnerSessionRuntimeId;
 
         if (!DoNotRemove && DelayRemove > 0)
         {
@@ -32,11 +39,16 @@ internal sealed class SessionRoamingFlgComponent : Entity
             if (sceneRoamingComponent.TryGet(roamingId, out var roamingComponent))
             {
                 await roamingComponent.StopForwarding();
-                await sceneRoamingComponent.Remove(roamingId, 0, DelayRemove);
+                await sceneRoamingComponent.Remove(
+                    roamingId,
+                    0,
+                    DelayRemove,
+                    ownerSessionRuntimeId);
             }
         }
 
         DelayRemove = 0;
+        OwnerSessionRuntimeId = 0;
         DoNotRemove = false;
         _isInnerDisposed = false;
         


### PR DESCRIPTION
问题复现：
1. 客户端登录并建立 Roaming 后断开，SessionRoamingFlgComponent.DisposeAsync 会按默认 180000 ms 安排延迟删除。
2. 在 180 秒内使用相同 roamingId（业务中为 userId）重新登录，并让新 Session 持续调用 Hall/Roaming 协议。
3. 到达旧 Session 的 180 秒触发点后，旧任务仅按 roamingId 查找当前组件，可能删除重连后新 Session 正在使用的 SessionRoamingComponent。
4. 客户端表现为任意 Roaming 协议偶发 session is dispose 或连接被远端关闭；服务端可出现 SessionRoamingComponent.Call 的 NullReferenceException。再次操作或重新连接后可能暂时恢复，因此容易被误判为网络底层抖动。

根因：
- 延迟任务只携带 roamingId，没有记录创建该任务的 Session 身份。
- InnerRemove 在定时器触发时会按 roamingId 获取字典中的当前组件，无法区分旧组件和重连后的新组件。
- 原有 CancelRemoveTask 只在复用已有组件且 Parent 为空的分支执行，无法覆盖创建新组件的分支。
- 即使新 Session 已取消旧任务，旧 Session 的 DisposeAsync 也可能在 StopForwarding await 之后恢复，再次登记一个 180 秒删除任务，形成竞态。

修复方案：
- 在 SessionRoamingComponent 和 SessionRoamingFlgComponent 中记录 OwnerSessionRuntimeId，标识组件与清理任务所属的 Session 世代。
- 新 Session 绑定相同 roamingId 时立即取消已登记的旧任务，并在后续 await 前切换 OwnerSessionRuntimeId。
- Remove 和 InnerRemove 接收 expectedOwnerSessionRuntimeId，在安排任务前及定时器真正执行时分别校验 owner。
- owner 不一致时直接忽略旧清理流程，确保旧 Session 只能清理自己创建的漫游绑定，不能删除新 Session 的组件。
- Fantasy.Net 与 Fantasy.Unity 两套实现保持同步。

验证结果：
- Fantasy.Net Release 编译通过，net8.0、net9.0、net10.0 均为 0 警告、0 错误。
- 修复打包为 Fantasy-Net 2026.1.1001-V2，并在 DMM K8s 更新后使用同一 Gate 进行回归。
- 旧 Session 断开后 3 秒重连，新 Session 每秒调用一次 Hall 协议并保持 195000 ms。
- 第 180 次探测发生在旧 Session 销毁约 190695 ms 后仍成功，最终约 199 秒正常结束，共完成 188 次探测。
- 客户端未出现 EndOfStreamException、session is dispose 或异常断线；Gate 日志中 SessionRoamingComponent.Call 和 NullReferenceException 均为 0，相关 Pod 重启数为 0。